### PR TITLE
Rad token vesting

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,8 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.6.2"]
+    "compiler-version": ["error", "^0.6.2"],
+    "reason-string": ["warn", {"maxLength": 96}],
+    "not-rely-on-time": "off"
   }
 }

--- a/contracts/Rad.sol
+++ b/contracts/Rad.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.6.2;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Rad is ERC20 {
-    uint256 public constant MAX_SUPPLY = 100000000e18;
-
     /// Construct a new Rad token.
     ///
     /// @param account The initial account to grant all the tokens
@@ -14,11 +12,6 @@ contract Rad is ERC20 {
         public
         ERC20("Rad", "RAD")
     {
-        require(
-            initialSupply <= MAX_SUPPLY,
-            "The starting supply cannot be more than the max"
-        );
-
         _mint(account, initialSupply.mul(10**uint256(decimals())));
     }
 }

--- a/contracts/Rad.sol
+++ b/contracts/Rad.sol
@@ -4,14 +4,21 @@ pragma solidity ^0.6.2;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Rad is ERC20 {
-    /*
-     * @notice Construct a new Rad token.
-     * @param account The initial account to grant all the tokens
-     */
-    constructor(address account, uint256 _totalSupply)
+    uint256 public constant MAX_SUPPLY = 100000000e18;
+
+    /// Construct a new Rad token.
+    ///
+    /// @param account The initial account to grant all the tokens
+    /// @param initialSupply The initial amount of Rad tokens.
+    constructor(address account, uint256 initialSupply)
         public
         ERC20("Rad", "RAD")
     {
-        _mint(account, _totalSupply.mul(10**uint256(decimals())));
+        require(
+            initialSupply <= MAX_SUPPLY,
+            "The starting supply cannot be more than the max"
+        );
+
+        _mint(account, initialSupply.mul(10**uint256(decimals())));
     }
 }

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -1,0 +1,153 @@
+//SPDX-License-Identifier: ISC
+pragma solidity ^0.6.2;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import "./Rad.sol";
+
+/// A token allocation of vRad.
+struct Allocation {
+    /// Vesting start time in seconds since Epoch.
+    uint256 vestingStart;
+    /// Vesting cliff duration.
+    uint256 vestingCliffDuration;
+    /// Vesting total (including cliff) duration in seconds.
+    uint256 vestingDuration;
+}
+
+/// The vRad (vesting) token.
+contract VRad is ERC20 {
+    /// The Rad token.
+    Rad private immutable rad;
+
+    /// Token allocations.
+    mapping(address => Allocation) public allocations;
+
+    /// The grantor of token allocations.
+    address public grantor;
+
+    /// Construct a new VRad token.
+    ///
+    /// @param _rad The address of the Rad ERC20 contract.
+    /// @param _grantor The initial account to grant all the tokens to.
+    constructor(address _rad, address _grantor) public ERC20("vRad", "vRAD") {
+        rad = Rad(_rad);
+        grantor = _grantor;
+    }
+
+    /// Expand the supply of Rad and vRad held by this contract equally.
+    function expandTokenSupply(uint256 amount) public {
+        // TODO: Approve sender?
+
+        // Transfer the Rad.
+        require(
+            rad.transferFrom(msg.sender, address(this), amount),
+            "The transfer in should succeed"
+        );
+        // Mint an equal amount of vRad.
+        _mint(address(this), amount);
+    }
+
+    /// Shrink the supply of Rad and vRad held by this contract equally.
+    function shrinkTokenSupply(address payable receiver, uint256 amount)
+        internal
+    {
+        // Transfer out an equal amount of Rad from the contract to the receiver.
+        require(
+            rad.transferFrom(address(this), receiver, amount),
+            "The transfer out should succeed"
+        );
+        // Burn an amount of vRad from the sender.
+        _burn(msg.sender, amount);
+    }
+
+    /// Allocate vesting tokens to an address.
+    function allocateTokens(
+        address grantee,
+        uint256 amount,
+        uint32 vestingStart,
+        uint32 vestingCliffDuration,
+        uint32 vestingDuration
+    ) public {
+        require(
+            balanceOf(grantee) == 0,
+            "Grantee must not already have an allocation"
+        );
+        require(
+            vestingDuration >= vestingCliffDuration,
+            "Cliff must not be longer than total duration"
+        );
+
+        // Nb. It's okay for the vesting/cliff duration to be zero.
+
+        _allocate(grantee, amount);
+
+        allocations[grantee].vestingStart = vestingStart;
+        allocations[grantee].vestingCliffDuration = vestingCliffDuration;
+        allocations[grantee].vestingDuration = vestingDuration;
+    }
+
+    /// Increase the vesting token allocation of an address.
+    function increaseAllocation(address grantee, uint256 amount) public {
+        require(
+            balanceOf(grantee) > 0,
+            "Grantee must already have an allocation"
+        );
+
+        _allocate(grantee, amount);
+    }
+
+    /// Get the amount of currently vested tokens for an address.
+    function getVestedAmount(address grantee) public view returns (uint256) {
+        uint256 vestingAmount = balanceOf(grantee);
+
+        require(vestingAmount > 0, "Grantee must already have an allocation");
+
+        Allocation memory alloc = allocations[grantee];
+        uint256 elapsed = now - alloc.vestingStart;
+
+        if (elapsed < alloc.vestingCliffDuration) {
+            return 0;
+        }
+
+        if (alloc.vestingDuration == 0) {
+            return vestingAmount;
+        }
+
+        uint256 vestedAmount = (elapsed / alloc.vestingDuration) *
+            vestingAmount;
+
+        if (vestedAmount > vestingAmount) {
+            vestedAmount = vestingAmount;
+        }
+
+        return vestedAmount;
+    }
+
+    /// Redeem vRad tokens for Rad tokens.
+    function redeemTokens(address payable receiver, uint256 amount) public {
+        require(amount > 0, "Redeem amount must be positive");
+        require(
+            getVestedAmount(msg.sender) >= amount,
+            "Redeem amount should be vested"
+        );
+
+        shrinkTokenSupply(receiver, amount);
+    }
+
+    /// Transfer the given amount of tokens from the contract to the grantee.
+    function _allocate(address grantee, uint256 amount) internal {
+        require(msg.sender == grantor, "Only the grantor can allocate tokens");
+        require(grantee != address(0), "Grantee cannot be the zero address");
+        require(
+            amount <= balanceOf(address(this)),
+            "Cannot allocate more than the allowance"
+        );
+
+        // Make the actual transfer.
+        require(
+            transferFrom(address(this), grantee, amount),
+            "Transfer from contract must be valid"
+        );
+    }
+}

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -169,9 +169,19 @@ contract VRad is ERC20 {
         );
 
         // Make the actual transfer.
-        require(
-            transferFrom(address(this), grantee, amount),
-            "Transfer from contract must be valid"
-        );
+        _transfer(address(this), grantee, amount);
+    }
+
+    /// Transfer of vRad is only allowed by the grantor.
+    function transfer(address recipient, uint256 amount)
+        public
+        override
+        returns (bool)
+    {
+        require(msg.sender == grantor, "Only the grantor can transfer vRad");
+
+        _transfer(msg.sender, recipient, amount);
+
+        return true;
     }
 }

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -158,6 +158,10 @@ contract VRad is ERC20 {
         );
 
         shrinkTokenSupply(receiver, amount);
+
+        if (balanceOf(msg.sender) == 0) {
+            delete allocations[msg.sender];
+        }
     }
 
     /// Transfer the given amount of tokens from the contract to the grantee.

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -63,8 +63,6 @@ contract VRad is ERC20 {
     /// Expand the supply of Rad and vRad held by this contract equally,
     /// by transfering Rad from the sender to the contract.
     function expandTokenSupply(address sender, uint256 amount) public {
-        // TODO: Approve sender?
-
         // Transfer the Rad.
         require(
             rad.transferFrom(sender, address(this), amount),

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: ISC
+// SPDX-License-Identifier: ISC
 pragma solidity ^0.6.2;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -15,7 +15,31 @@ struct Allocation {
     uint256 vestingDuration;
 }
 
-/// The vRad (vesting) token.
+/// The vRad token.
+///
+/// This contract implements a simple vesting token (vRad) that can be redeemed
+/// for an equal amount of Rad when the vesting period is over.
+///
+/// The general idea is the following:
+///
+/// 1. The contract is initialized with a "grantor" who has the right
+///    to grant vRad to an address. The contract starts out with a zero
+///    balance.
+/// 2. The contract supply is expanded via `expandTokenSupply`. With this
+///    method, the sender can transfer Rad to mint an equal amount of vRad
+///    into the contract's supply. The contract now holds an equal amount of
+///    Rad and vRad.
+/// 3. When the grantor wants to grant tokens to an address, they call
+///    `allocateTokens`. This simply transfers vRad from the contract
+///    to the "grantee", and records the vesting rules for that allocation.
+/// 4. The grantee can then call `getVestedAmount` at all times to check their
+///    amount of vested tokens.
+/// 5. When this amount is non-zero, the grantee can redeem vRad for Rad, by
+///    calling `redeemTokens` with an amount. As long as this amount isn't
+///    greater than the vested amount, the contract supply is shrunk via
+///    `shrinkTokenSupply`: the specified amount of vRad is burned, and an
+///    equal amount of Rad is transfered from the contract to the redeemer.
+///
 contract VRad is ERC20 {
     /// The Rad token.
     Rad private immutable rad;

--- a/contracts/VRad.sol
+++ b/contracts/VRad.sol
@@ -6,12 +6,13 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./Rad.sol";
 
 /// A token allocation of vRad.
+///
+/// @param vestingStart Vesting start time in seconds since Epoch.
+/// @param vestingCliffDuration Vesting cliff duration.
+/// @param vestingDuration Vesting total (including cliff) duration in seconds.
 struct Allocation {
-    /// Vesting start time in seconds since Epoch.
     uint256 vestingStart;
-    /// Vesting cliff duration.
     uint256 vestingCliffDuration;
-    /// Vesting total (including cliff) duration in seconds.
     uint256 vestingDuration;
 }
 
@@ -41,7 +42,7 @@ struct Allocation {
 ///    equal amount of Rad is transfered from the contract to the redeemer.
 ///
 contract VRad is ERC20 {
-    /// The Rad token.
+    /// @dev The Rad token.
     Rad private immutable rad;
 
     /// Token allocations.

--- a/test/vrad.test.ts
+++ b/test/vrad.test.ts
@@ -1,0 +1,90 @@
+import * as Ethers from "ethers";
+import buidler from "@nomiclabs/buidler";
+import {assert} from "chai";
+
+import {
+  VRadFactory,
+  RadFactory,
+} from "../ethers-contracts";
+
+/// Submit a transaction and wait for it to be mined. Then assert that it succeeded.
+async function submit(tx: Promise<Ethers.ContractTransaction>): Promise<Ethers.ContractReceipt> {
+  const receipt = await (await tx).wait();
+  assert.equal(receipt.status, 1, "transaction must be successful");
+
+  return receipt;
+}
+
+/// Let a certain amount of time pass.
+async function elapse(time: number) {
+  await buidler.ethers.provider.send('evm_increaseTime', [time]);
+  await buidler.ethers.provider.send('evm_mine', []);
+}
+
+describe("VRad", function () {
+  it("is a vesting token", async function () {
+    const [owner, grantor, grantee, treasury] = await buidler.ethers.getSigners();
+    const grantorAddress = await grantor.getAddress();
+    const treasuryAddress = await treasury.getAddress();
+    const granteeAddress = await grantee.getAddress();
+
+    const rad = await new RadFactory(owner).deploy(treasuryAddress, 100);
+    const vrad = await new VRadFactory(owner).deploy(rad.address, grantorAddress);
+
+    // Treasury balance is greater than zero.
+    assert((await rad.balanceOf(treasuryAddress)).gt(0));
+
+    // Approve the treasury to transfer Rad to the contract.
+    await submit(rad.connect(treasury).approve(vrad.address, 100));
+
+    // Check allowance.
+    assert.equal((await rad.allowance(treasuryAddress, vrad.address)).toNumber(), 100);
+
+    // Expand token supply.
+    await submit(
+      vrad.connect(treasury).expandTokenSupply(treasuryAddress, 70)
+    );
+
+    // Since the grantee hasn't been granted anything, he should have zero allocation.
+    assert.equal((await vrad.getVestedAmount(granteeAddress)).toNumber(), 0);
+
+    // Get the current (block) time.
+    const now = await vrad.getTime();
+    // Cliff duration (1 day)
+    const vestingCliff = 60 * 60 * 24;
+    // Total vesting duration (1 week)
+    const vestingTotal = vestingCliff * 7;
+
+    // Allocate some tokens to the grantee.
+    await submit(vrad.connect(grantor).allocateTokens(
+      granteeAddress,
+      70, // 10 Rad (smallest denomination)
+      now, // Start time of vesting
+      vestingCliff,
+      vestingTotal,
+    ));
+
+    // The grantee should now have tokens vesting.
+    assert.equal((await vrad.getVestingAmount(granteeAddress)).toNumber(), 70);
+    // ... but nothing vested yet.
+    assert.equal((await vrad.getVestedAmount(granteeAddress)).toNumber(), 0);
+
+    // Advance time by half the cliff period.
+    await elapse(vestingCliff / 2);
+
+    // Since we're still within the cliff, nothing is vested.
+    assert.equal((await vrad.getVestedAmount(granteeAddress)).toNumber(), 0);
+
+    // Advance time until the cliff is passed.
+    await elapse(vestingCliff / 2);
+
+    // Cliff is passed, we vested 1/7.
+    assert.equal((await vrad.getVestedAmount(granteeAddress)).toNumber(), 10);
+
+    // Redeem our vested tokens.
+    await submit(vrad.connect(grantee).redeemTokens(granteeAddress, 10));
+
+    // Grantee Rad balance is 1/7 of vested.
+    assert((await rad.balanceOf(granteeAddress)).eq(10));
+  });
+});


### PR DESCRIPTION
```
/// The vRad token.
///
/// This contract implements a simple vesting token (vRad) that can be redeemed
/// for an equal amount of Rad when the vesting period is over.
///
/// The general idea is the following:
///
/// 1. The contract is initialized with a "grantor" who has the right
///    to grant vRad to an address. The contract starts out with a zero
///    balance.
/// 2. The contract supply is expanded via `expandTokenSupply`. With this
///    method, the sender can transfer Rad to mint an equal amount of vRad
///    into the contract's supply. The contract now holds an equal amount of
///    Rad and vRad.
/// 3. When the grantor wants to grant tokens to an address, they call
///    `allocateTokens`. This simply transfers vRad from the contract
///    to the "grantee", and records the vesting rules for that allocation.
/// 4. The grantee can then call `getVestedAmount` at all times to check their
///    amount of vested tokens.
/// 5. When this amount is non-zero, the grantee can redeem vRad for Rad, by
///    calling `redeemTokens` with an amount. As long as this amount isn't
///    greater than the vested amount, the contract supply is shrunk via
///    `shrinkTokenSupply`: the specified amount of vRad is burned, and an
///    equal amount of Rad is transfered from the contract to the redeemer.
///
```

