### PR TITLE
Add function to deploy contracts for development

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -8,6 +8,8 @@
   agents:
     platform: "linux"
     production: "true"
+  artifact_paths:
+    - "radicle-contracts-*.tgz"
 
 steps:
   - branches: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Radicle Ethereum Contracts
 
 See [`DEVELOPING.md`](./DEVELOPING.md) for the developer manual.
+
+## Installation
+
+We provide a tarball of the package through [our
+CI](https://buildkite.com/monadic/radicle-contracts). See the “Artifacts”
+section of a build.

--- a/ci/run
+++ b/ci/run
@@ -14,8 +14,27 @@ yarn install --frozen-lockfile
 echo "--- lint"
 yarn run lint
 
-echo "--- build"
-yarn run build
+echo "--- build && pack"
+yarn pack
 
 echo "--- test"
 yarn run test
+
+if [[ -n "${BUILDKITE_TAG:-}" ]]
+then
+    declare -r artifact_scope="${BUILDKITE_TAG}"
+elif [[ "${BUILDKITE_BRANCH}" == "master" ]]
+then
+    declare -r artifact_scope="master/${BUILDKITE_COMMIT}"
+else
+    declare -r artifact_scope="$BUILDKITE_JOB_ID"
+fi
+declare -r artifact_prefix="https://builds.radicle.xyz/radicle-contracts/${artifact_scope}"
+
+{
+  echo "Artifacts"
+  for path in radicle-contracts-v*.tgz; do
+    url="${artifact_prefix}/${path}"
+    echo "* [\`${path}\`](${url})"
+  done
+} | buildkite-agent annotate --context node-binary --style success

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "radicle-contracts",
   "version": "0.0.0",
   "license": "GPL-3.0-only",
-  "dependencies": {},
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
   "devDependencies": {
     "@ensdomains/ens": "^0.4.4",
     "@nomiclabs/buidler": "^1.4.3",
@@ -29,7 +30,7 @@
   },
   "scripts": {
     "build": "buidler compile && tsc",
-    "prepack": "buidler compile",
+    "prepack": "yarn build",
     "test": "buidler test",
     "lint": "yarn run lint:prettier:check && yarn run lint:solhint && yarn run lint:eslint",
     "lint:solhint": "solhint --max-warnings=0 $(git ls-files | grep -E '\\.sol$')",
@@ -37,5 +38,10 @@
     "lint:prettier": "prettier $(git ls-files | grep -E '\\.(sol|ts|js)$')",
     "lint:prettier:check": "yarn lint:prettier --check",
     "lint:prettier:write": "yarn lint:prettier --write"
-  }
+  },
+  "files": [
+    "src/**",
+    "build/**",
+    "ethers-contracts/**"
+  ]
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -27,21 +27,15 @@ export async function deployDev(
   signer: ethers.Signer
 ): Promise<DeployedContracts> {
   const signerAddr = await signer.getAddress();
-
   const oracle = await new DummyPriceOracleFactory(signer).deploy(1);
-
   const ens = await new DummyEnsRegistryFactory(signer).deploy();
-
   const rad = await new RadFactory(signer).deploy(signerAddr, 1e6);
-
   const router = await new DummyRouterFactory(signer).deploy(rad.address);
-
   const exchange = await new ExchangeFactory(signer).deploy(
     rad.address,
     router.address,
     oracle.address
   );
-
   const registrar = await new RegistrarFactory(signer).deploy(
     ens.address,
     ensUtils.nameHash("radicle.eth"),

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -43,16 +43,14 @@ export async function deployDev(
     exchange.address,
     rad.address
   );
-  await registrar.deployed();
 
+  await registrar.deployed();
   await oracle.deployed();
   await ens.deployed();
   await rad.deployed();
   await router.deployed();
   await exchange.deployed();
-
   await (await rad.connect(signer).transfer(router.address, 1e3)).wait();
-
   await submitOk(
     ens.setSubnodeOwner(
       ensUtils.nameHash(""),
@@ -60,7 +58,6 @@ export async function deployDev(
       signerAddr
     )
   );
-
   await submitOk(
     ens.setSubnodeOwner(
       ensUtils.nameHash("eth"),

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,0 +1,93 @@
+import assert from "assert";
+import * as ethers from "ethers";
+
+import {Registrar} from "../ethers-contracts/Registrar";
+import {Rad} from "../ethers-contracts/Rad";
+import {Ens} from "../ethers-contracts/Ens";
+import {Exchange} from "../ethers-contracts/Exchange";
+import {
+  DummyPriceOracleFactory,
+  DummyEnsRegistryFactory,
+  RadFactory,
+  DummyRouterFactory,
+  ExchangeFactory,
+  RegistrarFactory,
+} from "../ethers-contracts";
+import * as ensUtils from "./ens";
+
+export interface DeployedContracts {
+  registrar: Registrar;
+  exchange: Exchange;
+  rad: Rad;
+  ens: Ens;
+}
+
+// Deploy development contract infrastructure.
+export async function deployDev(
+  signer: ethers.Signer
+): Promise<DeployedContracts> {
+  const signerAddr = await signer.getAddress();
+
+  const oracle = await new DummyPriceOracleFactory(signer).deploy(1);
+
+  const ens = await new DummyEnsRegistryFactory(signer).deploy();
+
+  const rad = await new RadFactory(signer).deploy(signerAddr, 1e6);
+
+  const router = await new DummyRouterFactory(signer).deploy(rad.address);
+
+  const exchange = await new ExchangeFactory(signer).deploy(
+    rad.address,
+    router.address,
+    oracle.address
+  );
+
+  const registrar = await new RegistrarFactory(signer).deploy(
+    ens.address,
+    ensUtils.nameHash("radicle.eth"),
+    oracle.address,
+    exchange.address,
+    rad.address
+  );
+  await registrar.deployed();
+
+  await oracle.deployed();
+  await ens.deployed();
+  await rad.deployed();
+  await router.deployed();
+  await exchange.deployed();
+
+  await (await rad.connect(signer).transfer(router.address, 1e3)).wait();
+
+  await submitOk(
+    ens.setSubnodeOwner(
+      ensUtils.nameHash(""),
+      ensUtils.labelHash("eth"),
+      signerAddr
+    )
+  );
+
+  await submitOk(
+    ens.setSubnodeOwner(
+      ensUtils.nameHash("eth"),
+      ensUtils.labelHash("radicle"),
+      registrar.address
+    )
+  );
+
+  return {
+    registrar,
+    exchange,
+    rad,
+    ens,
+  };
+}
+
+async function submitOk(
+  tx: Promise<ethers.ContractTransaction>
+): Promise<ethers.ContractReceipt> {
+  const receipt = await (await tx).wait();
+  assert.equal(receipt.status, 1, "transaction must be successful");
+
+  return receipt;
+}

--- a/src/ens.ts
+++ b/src/ens.ts
@@ -1,0 +1,21 @@
+import * as ethers from "ethers";
+
+// Return the hash of an ENS domain name as a hex string with leading `0x`.
+//
+// See https://docs.ens.domains/contract-api-reference/name-processing#hashing-names
+export function nameHash(name: string): string {
+  let node =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+  if (name == "") {
+    return node;
+  }
+  for (const label of name.split(".").reverse()) {
+    node = ethers.utils.keccak256(node + labelHash(label).slice(2));
+  }
+  return node;
+}
+
+// Return the hash of an ENS label as a hex string with leading `0x`.
+export function labelHash(label: string): string {
+  return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(label));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export {deployDev, DeployedContracts} from "./deploy";

--- a/test/registrar.test.ts
+++ b/test/registrar.test.ts
@@ -1,95 +1,27 @@
-// radicle.eth = 0x1e8e223921cb10fa256008149efd13dc5089bb252c6270e8be840a020e2e6416
-// cloudhead.radicle.eth = 0x567c364804de7bbedb53f583e483f6b73513fd2f44299e281024e4719da0b332
-// treehead.radicle.eth = 0x151be02f47af592d39e263c0a38443a2da15cdffcaf1e57ab2be0c047c88a4a1
-
 import {ethers} from "@nomiclabs/buidler";
 import {assert} from "chai";
 import {submit} from "./support";
+import {deployDev} from "../src/deploy";
+import * as ensUtils from "../src/ens";
 
 describe("Registrar", function () {
   it("should allow registration of names", async function () {
     const [owner, registrant] = await ethers.getSigners();
-    const ownerAddr = await owner.getAddress();
-
-    const zeroNode =
-      "0x0000000000000000000000000000000000000000000000000000000000000000";
-    const radicleNode =
-      "0x1e8e223921cb10fa256008149efd13dc5089bb252c6270e8be840a020e2e6416";
-
-    const ethLabel = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("eth"));
-    const radicleLabel = ethers.utils.keccak256(
-      ethers.utils.toUtf8Bytes("radicle")
-    );
-    const cloudheadLabel = ethers.utils.keccak256(
-      ethers.utils.toUtf8Bytes("cloudhead")
-    );
-
-    const Oracle = await ethers.getContractFactory("DummyPriceOracle");
-    const oracle = await Oracle.connect(owner).deploy(1);
-
-    const ENS = await ethers.getContractFactory("DummyEnsRegistry");
-    const ens = await ENS.connect(owner).deploy();
-
-    const Rad = await ethers.getContractFactory("Rad");
-    const rad = await Rad.connect(owner).deploy(ownerAddr, 1e6);
-
-    const Router = await ethers.getContractFactory("DummyRouter");
-    const router = await Router.connect(owner).deploy(rad.address);
-
-    await submit(rad.connect(owner).transfer(router.address, 1e3));
-
-    const Exchange = await ethers.getContractFactory("Exchange");
-    const exchange = await Exchange.connect(owner).deploy(
-      rad.address,
-      router.address,
-      oracle.address
-    );
-
-    const Registrar = await ethers.getContractFactory("Registrar");
-    const registrar = await Registrar.connect(owner).deploy(
-      ens.address,
-      radicleNode,
-      oracle.address,
-      exchange.address,
-      rad.address
-    );
-
-    await oracle.deployed();
-    await ens.deployed();
-    await registrar.deployed();
-    await rad.deployed();
-
-    const ethNode = await registrar.namehash(zeroNode, ethLabel);
-    const cloudheadNode = await registrar.namehash(radicleNode, cloudheadLabel);
+    const {rad, registrar, ens} = await deployDev(owner);
     const registrantAddr = await registrant.getAddress();
     const fee = (await registrar.registrationFee()).toNumber();
     const initialSupply = await rad.totalSupply();
-
-    // Create the `.eth` node, with `owner` as its owner.
-    await submit(
-      ens.connect(owner).setSubnodeOwner(zeroNode, ethLabel, ownerAddr)
-    );
-    assert.equal(await ens.owner(ethNode), ownerAddr);
-
-    // Create `radicle.eth`.
-    await submit(
-      ens
-        .connect(owner)
-        .setSubnodeOwner(ethNode, radicleLabel, registrar.address)
-    );
-    assert.equal(await ens.owner(radicleNode), registrar.address);
 
     // Check name availability.
     assert(await registrar.available("cloudhead"));
     assert(await registrar.available("treehead"));
 
     // Register `cloudhead.radicle.eth`.
-    await submit(
-      registrar
-        .connect(owner)
-        .register("cloudhead", registrantAddr, {value: fee})
+    await submit(registrar.register("cloudhead", registrantAddr, {value: fee}));
+    assert.equal(
+      await ens.owner(ensUtils.nameHash("cloudhead.radicle.eth")),
+      registrantAddr
     );
-    assert.equal(await ens.owner(cloudheadNode), registrantAddr);
     assert(!(await registrar.available("cloudhead")));
 
     // Check that the burn happened.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
-  "include": ["**/*.ts"],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "ethers-contracts/**/*.ts"
+  ],
   "exclude": ["node_modules"],
   "files": [
-    "./buidler.config.ts",
+    "buidler.config.ts",
     "node_modules/@nomiclabs/buidler-ethers/src/type-extensions.d.ts"
   ],
   "compilerOptions": {
@@ -12,15 +16,16 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    // ES2019 is supported starting with NodeJS v12
+    "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     "outDir": "./build",
@@ -53,7 +58,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
* Add a function `deployDev` that deploys development contract infrastructure.
* Use `deployDev` in tests
* Expose `deployDev` as part of the package
* Add ENS helper functions to better deal with name and label hashes
* Add package tarball to build artifacts so we can use it from other projects (i.e. upstream)