### PR TITLE
Deploy uniswap/ens backed contracts

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -6,9 +6,9 @@ import "./PriceOracle.sol";
 import "./Router.sol";
 
 contract Exchange {
-    Router private router;
-    PriceOracle private oracle;
-    address private rad;
+    Router public immutable router;
+    PriceOracle public immutable oracle;
+    address public immutable rad;
 
     constructor(
         address _rad,

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -40,6 +40,10 @@ contract Registrar {
         rootNode = _rootNode;
     }
 
+    function initialize() public {
+        oracle.updatePrices();
+    }
+
     /// Register a subdomain.
     function register(string memory name, address owner) public payable {
         // Make sure the oracle has up-to-date pricing information.

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -85,7 +85,7 @@ export async function deployDev(
 export async function deployExchange<P extends ethers.providers.Provider>(
   provider: P,
   signer: ethers.Signer
-) {
+): Promise<Exchange> {
   const signerAddr = await signer.getAddress();
 
   // Deploy tokens

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -32,7 +32,7 @@ export interface DeployedContracts {
 }
 
 // Deploy development contract infrastructure.
-export async function deployDev(
+export async function deployDummy(
   signer: ethers.Signer
 ): Promise<DeployedContracts> {
   const signerAddr = await signer.getAddress();

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -180,7 +180,7 @@ export async function deployExchange<P extends ethers.providers.Provider>(
     provider
   ).connect(signer);
 
-  // Transfer USD into the WETH/RAD pair.
+  // Transfer USD into the USD/WETH pair.
   await usdToken.transfer(usdWethAddr, toDecimals(10, 18));
 
   // Transfer WETH into the USD/WETH pair.

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -12,8 +12,16 @@ import {
   DummyRouterFactory,
   ExchangeFactory,
   RegistrarFactory,
+  FixedWindowOracleFactory,
+  StablePriceOracleFactory,
 } from "../ethers-contracts";
 import * as ensUtils from "./ens";
+
+import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Router02 from "@uniswap/v2-periphery/build/UniswapV2Router02.json";
+import ERC20 from "@uniswap/v2-periphery/build/ERC20.json";
+import WETH9 from "@uniswap/v2-periphery/build/WETH9.json";
+import IUniswapV2Pair from "@uniswap/v2-core/build/IUniswapV2Pair.json";
 
 export interface DeployedContracts {
   registrar: Registrar;
@@ -74,6 +82,95 @@ export async function deployDev(
   };
 }
 
+export async function deployExchange<P extends ethers.providers.Provider>(
+  provider: P,
+  signer: ethers.Signer
+) {
+  const signerAddr = await signer.getAddress();
+
+  // Deploy tokens
+  const radToken = await new RadFactory(signer).deploy(
+    signerAddr,
+    toDecimals(10000, 18)
+  );
+  const usdToken = await deployContract(signer, ERC20, [toDecimals(10000, 18)]);
+  const wethToken = await deployContract(signer, WETH9, []);
+
+  // Deposit ETH into WETH contract
+  await submitOk(
+    wethToken.connect(signer).deposit({value: toDecimals(100, 18)})
+  );
+
+  // Deploy Uniswap factory & router
+  const factory = await deployContract(signer, UniswapV2Factory, [signerAddr]);
+  const router = await deployContract(signer, UniswapV2Router02, [
+    factory.address,
+    wethToken.address,
+  ]);
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Create USD/WETH pair
+  await factory.createPair(usdToken.address, wethToken.address);
+  const usdWethAddr = await factory.getPair(
+    usdToken.address,
+    wethToken.address
+  );
+  const usdWethPair = new ethers.Contract(
+    usdWethAddr,
+    JSON.stringify(IUniswapV2Pair.abi),
+    provider
+  ).connect(signer);
+
+  // Transfer USD into the WETH/RAD pair.
+  await usdToken.transfer(usdWethAddr, toDecimals(10, 18));
+
+  // Transfer WETH into the USD/WETH pair.
+  await wethToken.connect(signer).transfer(usdWethAddr, toDecimals(10, 18));
+  await submitOk(usdWethPair.sync());
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Create WETH/RAD pair
+  await factory.createPair(wethToken.address, radToken.address);
+  const wethRadAddr = await factory.getPair(
+    wethToken.address,
+    radToken.address
+  );
+  const wethRadPair = new ethers.Contract(
+    wethRadAddr,
+    JSON.stringify(IUniswapV2Pair.abi),
+    provider
+  ).connect(signer);
+
+  // Transfer RAD into the WETH/RAD pair.
+  await radToken.transfer(wethRadAddr, toDecimals(10, 18));
+
+  // Transfer WETH into the WETH/RAD pair.
+  await wethToken.connect(signer).transfer(wethRadAddr, toDecimals(10, 18));
+  await submitOk(wethRadPair.sync());
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Deploy price oracle
+  const fixedWindowOracle = await new FixedWindowOracleFactory(signer).deploy(
+    factory.address,
+    usdToken.address,
+    wethToken.address
+  );
+  const oracle = await new StablePriceOracleFactory(signer).deploy(
+    fixedWindowOracle.address
+  );
+
+  const exchange = await new ExchangeFactory(signer).deploy(
+    radToken.address,
+    router.address,
+    oracle.address
+  );
+
+  return exchange;
+}
+
 async function submitOk(
   tx: Promise<ethers.ContractTransaction>
 ): Promise<ethers.ContractReceipt> {
@@ -81,4 +178,21 @@ async function submitOk(
   assert.equal(receipt.status, 1, "transaction must be successful");
 
   return receipt;
+}
+
+const deployContract = async (
+  signer: ethers.Signer,
+  contractJSON: any,
+  args: Array<any>
+) => {
+  const factory = new ethers.ContractFactory(
+    contractJSON.abi,
+    contractJSON.bytecode,
+    signer
+  );
+  return factory.deploy(...args);
+};
+
+function toDecimals(n: number, exp: number): ethers.BigNumber {
+  return ethers.BigNumber.from(n).mul(ethers.BigNumber.from(10).pow(exp));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {deployDev, DeployedContracts} from "./deploy";
+export {deployAll, DeployedContracts} from "./deploy";

--- a/test/registrar.test.ts
+++ b/test/registrar.test.ts
@@ -1,16 +1,29 @@
 import {ethers} from "@nomiclabs/buidler";
 import {assert} from "chai";
-import {submit} from "./support";
-import {deployDev} from "../src/deploy";
+import {submit, elapseTime} from "./support";
+import {deployAll} from "../src/deploy";
 import * as ensUtils from "../src/ens";
 
 describe("Registrar", function () {
   it("should allow registration of names", async function () {
     const [owner, registrant] = await ethers.getSigners();
-    const {rad, registrar, ens} = await deployDev(owner);
+    const {rad, registrar, ens} = await deployAll(
+      ethers.provider,
+      owner
+    );
     const registrantAddr = await registrant.getAddress();
+
+    // Let 24 hours pass. This is the minimum to ensure we have a price
+    // for our token pairs.
+    await elapseTime(60 * 60 * 24);
+
+    // Initialize the registrar.
+    await submit(registrar.initialize());
+
     const fee = (await registrar.registrationFee()).toNumber();
     const initialSupply = await rad.totalSupply();
+
+    assert(fee > 0, "Fee must be > 0");
 
     // Check name availability.
     assert(await registrar.available("cloudhead"));
@@ -24,8 +37,9 @@ describe("Registrar", function () {
     );
     assert(!(await registrar.available("cloudhead")));
 
-    // Check that the burn happened.
+    // Check that the burn happened. The exact amount swapped is always slightly
+    // lower than the exact conversion.
     const newSupply = await rad.totalSupply();
-    assert.equal(newSupply.sub(initialSupply).toNumber(), -fee);
+    assert.equal(newSupply.sub(initialSupply).toNumber(), -(fee - 1));
   });
 });

--- a/test/registrar.test.ts
+++ b/test/registrar.test.ts
@@ -7,10 +7,7 @@ import * as ensUtils from "../src/ens";
 describe("Registrar", function () {
   it("should allow registration of names", async function () {
     const [owner, registrant] = await ethers.getSigners();
-    const {rad, registrar, ens} = await deployAll(
-      ethers.provider,
-      owner
-    );
+    const {rad, registrar, ens} = await deployAll(ethers.provider, owner);
     const registrantAddr = await registrant.getAddress();
 
     // Let 24 hours pass. This is the minimum to ensure we have a price

--- a/test/support.ts
+++ b/test/support.ts
@@ -1,5 +1,6 @@
 import * as Ethers from "ethers";
 import {assert} from "chai";
+import buidler from "@nomiclabs/buidler";
 
 export async function wait(
   response: Promise<Ethers.ContractTransaction>
@@ -15,4 +16,10 @@ export async function submit(
   assert.equal(receipt.status, 1, "transaction must be successful");
 
   return receipt;
+}
+
+/// Let a certain amount of time pass.
+export async function elapseTime(time: number) {
+  await buidler.ethers.provider.send("evm_increaseTime", [time]);
+  await buidler.ethers.provider.send("evm_mine", []);
 }

--- a/test/vrad.test.ts
+++ b/test/vrad.test.ts
@@ -1,14 +1,8 @@
 import buidler from "@nomiclabs/buidler";
 import {assert} from "chai";
-import {submit} from "./support";
+import {submit, elapseTime} from "./support";
 
 import {VRadFactory, RadFactory} from "../ethers-contracts";
-
-/// Let a certain amount of time pass.
-async function elapse(time: number) {
-  await buidler.ethers.provider.send("evm_increaseTime", [time]);
-  await buidler.ethers.provider.send("evm_mine", []);
-}
 
 describe("VRad", function () {
   it("is a vesting token", async function () {
@@ -70,13 +64,13 @@ describe("VRad", function () {
     assert.equal((await vrad.vestedBalanceOf(granteeAddress)).toNumber(), 0);
 
     // Advance time by half the cliff period.
-    await elapse(vestingCliff / 2);
+    await elapseTime(vestingCliff / 2);
 
     // Since we're still within the cliff, nothing is vested.
     assert.equal((await vrad.vestedBalanceOf(granteeAddress)).toNumber(), 0);
 
     // Advance time until the cliff is passed.
-    await elapse(vestingCliff / 2);
+    await elapseTime(vestingCliff / 2);
 
     // Cliff is passed, we vested 1/7.
     assert.equal((await vrad.vestedBalanceOf(granteeAddress)).toNumber(), 10);


### PR DESCRIPTION
This sets up a deploy function, `deployAll` that deploys the bytecode of ENS and Uniswap, sets up proper liquidity pairs for Uniswap and hooks everything up with our contract. This allows us to test everything using the "real" contracts, instead of the dummy ones.

As you'll notice, the registration fee taken from the Uniswap price oracle is always going to be slightly lower than expected, eg. given a 1:1 liquidity ratio, the price of 1000 USD will be ~999 ETH.

* [x] Deploy Uniswap-based exchange
* [x] Deploy ENS-based registrar