### PR TITLE
Add 'prepare' script so package can be installed as git dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "buidler compile && tsc",
+    "prepare": "yarn prepack",
     "prepack": "yarn build",
     "test": "buidler test",
     "lint": "yarn run lint:prettier:check && yarn run lint:solhint && yarn run lint:eslint",


### PR DESCRIPTION
With this change the package can be installed as a git dependency with Yarn. See https://github.com/yarnpkg/yarn/issues/5235#issuecomment-571206092