### PR TITLE
Add web3 contract bindings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  ignorePatterns: ["build/**", "ethers-contracts/**", "cache/**"],
+  ignorePatterns: ["build/**", "contract-bindings/**", "cache/**"],
   rules: {
     "@typescript-eslint/explicit-function-return-type": "error",
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /artifacts
 /build
 /cache
-/ethers-contracts
+/contract-bindings
 /yarn-error.log
 /node_modules

--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -20,11 +20,10 @@ export default {
 task(TASK_COMPILE).setAction(async (_, {config}, runSuper) => {
   await runSuper();
 
-  const outDir = "./ethers-contracts";
-  await typeChain(`${config.paths.artifacts}/*.json`, outDir);
+  await typeChain(`${config.paths.artifacts}/*.json`, ".");
   await typeChain(
     "./node_modules/@uniswap/v2-*/build/UniswapV2*.json",
-    path.join(outDir, "uniswap-v2")
+    "uniswap-v2"
   );
 
   console.log(`Successfully generated Typechain artifacts!`);
@@ -39,17 +38,25 @@ task(TASK_COMPILE_GET_COMPILER_INPUT).setAction(async (_, __, runSuper) => {
   return input;
 });
 
-async function typeChain(files: string, outDir: string): Promise<void> {
+async function typeChain(files: string, modulePath: string): Promise<void> {
+  const outDir = "./contract-bindings";
   const cwd = process.cwd();
-  await tsGenerator(
-    {cwd},
+  await tsGenerator({cwd}, [
     new TypeChain({
       cwd,
       rawConfig: {
         files,
-        outDir,
+        outDir: path.join(outDir, "ethers", modulePath),
         target: "ethers-v5",
       },
-    })
-  );
+    }),
+    new TypeChain({
+      cwd,
+      rawConfig: {
+        files,
+        outDir: path.join(outDir, "web3", modulePath),
+        target: "web3-v1",
+      },
+    }),
+  ]);
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "types": "build/src/index.d.ts",
   "dependencies": {
     "@ensdomains/ens": "^0.4.4",
-    "ethers": "^5.0.14",
     "@ethersproject/abi": "^5.0.5",
+    "@typechain/web3-v1": "^1.0.0",
     "@uniswap/v2-core": "^1.0.1",
-    "@uniswap/v2-periphery": "^1.1.0-beta.0"
+    "@uniswap/v2-periphery": "^1.1.0-beta.0",
+    "ethers": "^5.0.14"
   },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.4.3",
@@ -46,6 +47,6 @@
   "files": [
     "src/**",
     "build/**",
-    "ethers-contracts/**"
+    "contract-bindings/**"
   ]
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -2,10 +2,10 @@ import assert from "assert";
 import * as ethers from "ethers";
 import * as abi from "@ethersproject/abi";
 
-import {Registrar} from "../ethers-contracts/Registrar";
-import {Rad} from "../ethers-contracts/Rad";
-import {Ens} from "../ethers-contracts/Ens";
-import {Exchange} from "../ethers-contracts/Exchange";
+import {Registrar} from "../contract-bindings/ethers/Registrar";
+import {Rad} from "../contract-bindings/ethers/Rad";
+import {Ens} from "../contract-bindings/ethers/Ens";
+import {Exchange} from "../contract-bindings/ethers/Exchange";
 import {
   DummyPriceOracleFactory,
   DummyEnsRegistryFactory,
@@ -15,7 +15,7 @@ import {
   RegistrarFactory,
   FixedWindowOracleFactory,
   StablePriceOracleFactory,
-} from "../ethers-contracts";
+} from "../contract-bindings/ethers";
 import * as ensUtils from "./ens";
 
 import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";

--- a/test/attestations.test.ts
+++ b/test/attestations.test.ts
@@ -1,7 +1,7 @@
 import {ethers} from "@nomiclabs/buidler";
 import {assert} from "chai";
 import {submit} from "./support";
-import {AttestationRegistryFactory} from "../ethers-contracts";
+import {AttestationRegistryFactory} from "../contract-bindings/ethers";
 
 describe("Attestations", function () {
   it("should allow attestations to be made and revoked", async function () {

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -1,6 +1,9 @@
-import {PoolFactory, ReceiverWeightsTestFactory} from "../ethers-contracts";
-import {Pool} from "../ethers-contracts/Pool";
-import {ReceiverWeightsTest} from "../ethers-contracts/ReceiverWeightsTest";
+import {
+  PoolFactory,
+  ReceiverWeightsTestFactory,
+} from "../contract-bindings/ethers";
+import {Pool} from "../contract-bindings/ethers/Pool";
+import {ReceiverWeightsTest} from "../contract-bindings/ethers/ReceiverWeightsTest";
 import buidler from "@nomiclabs/buidler";
 
 import {assert} from "chai";

--- a/test/vrad.test.ts
+++ b/test/vrad.test.ts
@@ -2,7 +2,7 @@ import buidler from "@nomiclabs/buidler";
 import {assert} from "chai";
 import {submit, elapseTime} from "./support";
 
-import {VRadFactory, RadFactory} from "../ethers-contracts";
+import {VRadFactory, RadFactory} from "../contract-bindings/ethers";
 
 describe("VRad", function () {
   it("is a vesting token", async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@
   dependencies:
     ethers "^5.0.2"
 
+"@typechain/web3-v1@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@typechain/web3-v1/-/web3-v1-1.0.0.tgz#842f925e45bdfb0d28e08c0e355f1c8efed7ea91"
+  integrity sha512-MM8PmsblePaxy5BCYEuPtR4ajigPf504VRQzZgFYqs6KuFnJxbOjF8jNYT12P6UvUX7us75Wc78QdbvOHbb4hA==
+
 "@types/bn.js@*", "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"


### PR DESCRIPTION
We add TypeScript contract bindings for the Web3 library. This requires
us to restructure the output folders for bindings.