### PR TITLE
Implement basic orgs

### DIFF
--- a/contracts/Org.sol
+++ b/contracts/Org.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.12;
+
+contract Org {
+    /// A project anchor under an org.
+    struct Project {
+        bytes32 rev; // Project revision hash
+        bytes32 hash; // Project state (eg. HEAD commit) hash
+    }
+
+    /// Org owner/admin.
+    address public owner;
+
+    /// Index of projects under this org, keyed by project identifier.
+    /// The values represent offsets into the `projects` array.
+    mapping(bytes32 => Project) public projects;
+
+    modifier ownerOnly {
+        require(msg.sender == owner, "Only the org owner can perform this action");
+        _;
+    }
+
+    /// Construct a new org instance, by providing an owner address.
+    constructor(address _owner) public {
+        owner = _owner;
+    }
+
+    /// Check whether a project exists.
+    function projectExists(bytes32 id) public returns (bool) {
+        return projects[id].hash != bytes32(0);
+    }
+
+    // ~ All functions below should use the `ownerOnly` modifier ~
+
+    /// Set the org owner.
+    function setOwner(address _owner) public ownerOnly {
+        owner = _owner;
+    }
+
+    /// Anchor a project state on chain, by providing a revision and hash. This method
+    /// should be used for adding new projects to the org, as well as updating
+    /// existing ones.
+    function anchorProject(
+        bytes32 id,
+        bytes32 rev,
+        bytes32 hash
+    ) public ownerOnly {
+        require(hash != bytes32(0), "The project hash must not be the zero hash");
+
+        Project storage proj = projects[id];
+
+        proj.rev = rev;
+        proj.hash = hash;
+    }
+
+    /// Remove a project from the org.
+    function removeProject(bytes32 id) public ownerOnly {
+        delete projects[id];
+    }
+}

--- a/contracts/Org.sol
+++ b/contracts/Org.sol
@@ -15,11 +15,6 @@ contract Org {
     /// The values represent offsets into the `projects` array.
     mapping(bytes32 => Project) public projects;
 
-    modifier ownerOnly {
-        require(msg.sender == owner, "Only the org owner can perform this action");
-        _;
-    }
-
     /// Construct a new org instance, by providing an owner address.
     constructor(address _owner) public {
         owner = _owner;
@@ -31,6 +26,12 @@ contract Org {
     }
 
     // ~ All functions below should use the `ownerOnly` modifier ~
+
+    /// Functions that can only be called by the contract owner.
+    modifier ownerOnly {
+        require(msg.sender == owner, "Only the org owner can perform this action");
+        _;
+    }
 
     /// Set the org owner.
     function setOwner(address _owner) public ownerOnly {

--- a/contracts/Org.sol
+++ b/contracts/Org.sol
@@ -21,7 +21,7 @@ contract Org {
     }
 
     /// Check whether a project exists.
-    function projectExists(bytes32 id) public returns (bool) {
+    function projectExists(bytes32 id) public view returns (bool) {
         return projects[id].hash != bytes32(0);
     }
 

--- a/test/org.test.ts
+++ b/test/org.test.ts
@@ -69,7 +69,9 @@ describe("Org", function () {
     // Should revert!
     await submit(org.connect(bob).anchorProject(id, rev, hash))
       .then(() => expect.fail("Expected error"))
-      .catch(() => {});
+      .catch(() => {
+        /* OK */
+      });
 
     // Ok
     await submit(org.connect(owner).anchorProject(id, rev, hash));
@@ -77,7 +79,9 @@ describe("Org", function () {
     // Should revert!
     await submit(org.connect(bob).removeProject(id))
       .then(() => expect.fail("Expected error"))
-      .catch(() => {});
+      .catch(() => {
+        /* OK */
+      });
   });
 
   it("should allow ownership to change", async function () {
@@ -90,7 +94,9 @@ describe("Org", function () {
     // Should revert!
     await submit(org.connect(bob).setOwner(bobAddr))
       .then(() => expect.fail("Expected error"))
-      .catch(() => {});
+      .catch(() => {
+        /* OK */
+      });
 
     // Ok
     await submit(org.connect(owner).setOwner(bobAddr));
@@ -98,7 +104,9 @@ describe("Org", function () {
     // Should revert!
     await submit(org.connect(owner).setOwner(ownerAddr))
       .then(() => expect.fail("Expected error"))
-      .catch(() => {});
+      .catch(() => {
+        /* OK */
+      });
 
     // Ok
     await submit(org.connect(bob).setOwner(ownerAddr));
@@ -109,8 +117,7 @@ describe("Org", function () {
     const ownerAddr = await owner.getAddress();
 
     const org = await new OrgFactory(owner).deploy(ownerAddr);
-
-    let ids = [];
+    const ids = [];
 
     for (let i = 0; i < 3; i++) {
       const id = ethers.utils.randomBytes(32);

--- a/test/org.test.ts
+++ b/test/org.test.ts
@@ -1,0 +1,28 @@
+import {ethers} from "@nomiclabs/buidler";
+import {assert} from "chai";
+import {submit} from "./support";
+import {
+  OrgFactory,
+} from "../contract-bindings/ethers";
+
+describe("Org", function () {
+  it("should behave like an org", async function () {
+    const [owner] = await ethers.getSigners();
+    const ownerAddr = await owner.getAddress();
+
+    const org = await new OrgFactory(owner).deploy(ownerAddr);
+
+    await org.deployed();
+
+    const acmeId = ethers.utils.randomBytes(32);
+    const acmeRev = ethers.utils.randomBytes(32);
+    const acmeHash = ethers.utils.randomBytes(32);
+
+    await submit(org.connect(owner).anchorProject(acmeId, acmeRev, acmeHash));
+
+    const proj = await org.projects(acmeId);
+
+    assert.equal(proj.rev, ethers.utils.hexlify(acmeRev));
+    assert.equal(proj.hash, ethers.utils.hexlify(acmeHash));
+  });
+});

--- a/test/org.test.ts
+++ b/test/org.test.ts
@@ -1,12 +1,10 @@
 import {ethers} from "@nomiclabs/buidler";
-import {assert} from "chai";
+import {assert, expect} from "chai";
 import {submit} from "./support";
-import {
-  OrgFactory,
-} from "../contract-bindings/ethers";
+import {OrgFactory} from "../contract-bindings/ethers";
 
 describe("Org", function () {
-  it("should behave like an org", async function () {
+  it("should allow a project to be anchored", async function () {
     const [owner] = await ethers.getSigners();
     const ownerAddr = await owner.getAddress();
 
@@ -14,15 +12,118 @@ describe("Org", function () {
 
     await org.deployed();
 
-    const acmeId = ethers.utils.randomBytes(32);
-    const acmeRev = ethers.utils.randomBytes(32);
-    const acmeHash = ethers.utils.randomBytes(32);
+    const id = ethers.utils.randomBytes(32);
+    const rev = ethers.utils.randomBytes(32);
+    const hash = ethers.utils.randomBytes(32);
 
-    await submit(org.connect(owner).anchorProject(acmeId, acmeRev, acmeHash));
+    // Create a new anchor.
 
-    const proj = await org.projects(acmeId);
+    assert.equal(await org.projectExists(id), false);
 
-    assert.equal(proj.rev, ethers.utils.hexlify(acmeRev));
-    assert.equal(proj.hash, ethers.utils.hexlify(acmeHash));
+    await submit(org.connect(owner).anchorProject(id, rev, hash));
+
+    assert.equal(await org.projectExists(id), true);
+
+    let proj = await org.projects(id);
+
+    assert.equal(proj.rev, ethers.utils.hexlify(rev));
+    assert.equal(proj.hash, ethers.utils.hexlify(hash));
+
+    // Update the anchor.
+
+    const newHash = ethers.utils.randomBytes(32);
+    await submit(org.connect(owner).anchorProject(id, rev, newHash));
+
+    proj = await org.projects(id);
+
+    assert.equal(proj.hash, ethers.utils.hexlify(newHash));
+
+    // Remove the anchor.
+
+    await submit(org.connect(owner).removeProject(id));
+    assert.equal(await org.projectExists(id), false);
+  });
+
+  it("should allow removing a project even if it doesn't exist", async function () {
+    const [owner] = await ethers.getSigners();
+    const ownerAddr = await owner.getAddress();
+
+    const org = await new OrgFactory(owner).deploy(ownerAddr);
+
+    const id = ethers.utils.randomBytes(32);
+    await submit(org.connect(owner).removeProject(id));
+  });
+
+  it("should only allow the org owner to anchor", async function () {
+    const [owner, bob] = await ethers.getSigners();
+    const ownerAddr = await owner.getAddress();
+
+    const org = await new OrgFactory(owner).deploy(ownerAddr);
+
+    await org.deployed();
+
+    const id = ethers.utils.randomBytes(32);
+    const rev = ethers.utils.randomBytes(32);
+    const hash = ethers.utils.randomBytes(32);
+
+    // Should revert!
+    await submit(org.connect(bob).anchorProject(id, rev, hash))
+      .then(() => expect.fail("Expected error"))
+      .catch(() => {});
+
+    // Ok
+    await submit(org.connect(owner).anchorProject(id, rev, hash));
+
+    // Should revert!
+    await submit(org.connect(bob).removeProject(id))
+      .then(() => expect.fail("Expected error"))
+      .catch(() => {});
+  });
+
+  it("should allow ownership to change", async function () {
+    const [owner, bob] = await ethers.getSigners();
+    const ownerAddr = await owner.getAddress();
+    const bobAddr = await bob.getAddress();
+
+    const org = await new OrgFactory(owner).deploy(ownerAddr);
+
+    // Should revert!
+    await submit(org.connect(bob).setOwner(bobAddr))
+      .then(() => expect.fail("Expected error"))
+      .catch(() => {});
+
+    // Ok
+    await submit(org.connect(owner).setOwner(bobAddr));
+
+    // Should revert!
+    await submit(org.connect(owner).setOwner(ownerAddr))
+      .then(() => expect.fail("Expected error"))
+      .catch(() => {});
+
+    // Ok
+    await submit(org.connect(bob).setOwner(ownerAddr));
+  });
+
+  it("should allow multiple projects anchored under an org", async function () {
+    const [owner] = await ethers.getSigners();
+    const ownerAddr = await owner.getAddress();
+
+    const org = await new OrgFactory(owner).deploy(ownerAddr);
+
+    let ids = [];
+
+    for (let i = 0; i < 3; i++) {
+      const id = ethers.utils.randomBytes(32);
+      const rev = ethers.utils.randomBytes(32);
+      const hash = ethers.utils.randomBytes(32);
+
+      await submit(org.connect(owner).anchorProject(id, rev, hash));
+
+      ids.push(id);
+    }
+
+    for (let i = 0; i < ids.length; i++) {
+      assert.equal(await org.projectExists(ids[i]), true);
+    }
   });
 });

--- a/test/org.test.ts
+++ b/test/org.test.ts
@@ -1,6 +1,6 @@
 import {ethers} from "@nomiclabs/buidler";
-import {assert, expect} from "chai";
-import {submit} from "./support";
+import {assert} from "chai";
+import {submit, submitFailing} from "./support";
 import {OrgFactory} from "../contract-bindings/ethers";
 
 describe("Org", function () {
@@ -67,21 +67,13 @@ describe("Org", function () {
     const hash = ethers.utils.randomBytes(32);
 
     // Should revert!
-    await submit(org.connect(bob).anchorProject(id, rev, hash))
-      .then(() => expect.fail("Expected error"))
-      .catch(() => {
-        /* OK */
-      });
+    await submitFailing(org.connect(bob).anchorProject(id, rev, hash));
 
     // Ok
     await submit(org.connect(owner).anchorProject(id, rev, hash));
 
     // Should revert!
-    await submit(org.connect(bob).removeProject(id))
-      .then(() => expect.fail("Expected error"))
-      .catch(() => {
-        /* OK */
-      });
+    await submitFailing(org.connect(bob).removeProject(id));
   });
 
   it("should allow ownership to change", async function () {
@@ -92,21 +84,13 @@ describe("Org", function () {
     const org = await new OrgFactory(owner).deploy(ownerAddr);
 
     // Should revert!
-    await submit(org.connect(bob).setOwner(bobAddr))
-      .then(() => expect.fail("Expected error"))
-      .catch(() => {
-        /* OK */
-      });
+    await submitFailing(org.connect(bob).setOwner(bobAddr));
 
     // Ok
     await submit(org.connect(owner).setOwner(bobAddr));
 
     // Should revert!
-    await submit(org.connect(owner).setOwner(ownerAddr))
-      .then(() => expect.fail("Expected error"))
-      .catch(() => {
-        /* OK */
-      });
+    await submitFailing(org.connect(owner).setOwner(ownerAddr));
 
     // Ok
     await submit(org.connect(bob).setOwner(ownerAddr));

--- a/test/support.ts
+++ b/test/support.ts
@@ -21,7 +21,9 @@ export async function submit(
 }
 
 /// Submit a transaction and expect it to fail. Throws an error if it succeeds.
-export async function submitFailing(tx: Promise<Ethers.ContractTransaction>) {
+export async function submitFailing(
+  tx: Promise<Ethers.ContractTransaction>
+): void {
   let succeeded = false;
 
   try {
@@ -30,7 +32,9 @@ export async function submitFailing(tx: Promise<Ethers.ContractTransaction>) {
     if (receipt.status == 1) {
       succeeded = true;
     }
-  } catch {}
+  } catch {
+    /* OK */
+  }
 
   if (succeeded) {
     expect.fail("Expected transaction to fail");

--- a/test/support.ts
+++ b/test/support.ts
@@ -13,7 +13,6 @@ export async function submit(
   tx: Promise<Ethers.ContractTransaction>
 ): Promise<Ethers.ContractReceipt> {
   const receipt = await (await tx).wait();
-  assert.equal(receipt.status, 1, "transaction must be successful");
 
   console.log("Gas used: ", receipt.gasUsed.toString());
 

--- a/test/support.ts
+++ b/test/support.ts
@@ -23,7 +23,7 @@ export async function submit(
 /// Submit a transaction and expect it to fail. Throws an error if it succeeds.
 export async function submitFailing(
   tx: Promise<Ethers.ContractTransaction>
-): void {
+): Promise<void> {
   let succeeded = false;
 
   try {

--- a/test/support.ts
+++ b/test/support.ts
@@ -1,5 +1,5 @@
 import * as Ethers from "ethers";
-import {assert, expect} from "chai";
+import {expect} from "chai";
 import buidler from "@nomiclabs/buidler";
 
 export async function wait(

--- a/test/support.ts
+++ b/test/support.ts
@@ -24,21 +24,12 @@ export async function submit(
 export async function submitFailing(
   tx: Promise<Ethers.ContractTransaction>
 ): Promise<void> {
-  let succeeded = false;
-
   try {
-    const receipt = await (await tx).wait();
-
-    if (receipt.status == 1) {
-      succeeded = true;
-    }
+    await (await tx).wait();
   } catch {
-    /* OK */
+    return;
   }
-
-  if (succeeded) {
-    expect.fail("Expected transaction to fail");
-  }
+  expect.fail("Expected transaction to fail");
 }
 
 /// Let a certain amount of time pass.

--- a/test/support.ts
+++ b/test/support.ts
@@ -1,5 +1,5 @@
 import * as Ethers from "ethers";
-import {assert} from "chai";
+import {assert, expect} from "chai";
 import buidler from "@nomiclabs/buidler";
 
 export async function wait(
@@ -18,6 +18,23 @@ export async function submit(
   console.log("Gas used: ", receipt.gasUsed.toString());
 
   return receipt;
+}
+
+/// Submit a transaction and expect it to fail. Throws an error if it succeeds.
+export async function submitFailing(tx: Promise<Ethers.ContractTransaction>) {
+  let succeeded = false;
+
+  try {
+    const receipt = await (await tx).wait();
+
+    if (receipt.status == 1) {
+      succeeded = true;
+    }
+  } catch {}
+
+  if (succeeded) {
+    expect.fail("Expected transaction to fail");
+  }
 }
 
 /// Let a certain amount of time pass.


### PR DESCRIPTION
Addresses parts of #21 

This changeset doesn't implement the full org functionality; only project anchoring. The rest will come in subsequent changesets.

An org contract is meant to be deployed per org. This allows orgs to have an address, and makes the contract a little simpler.