### PR TITLE
Add lints for type checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,8 +4,15 @@ module.exports = {
     node: true,
   },
   parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.eslint.json",
+  },
   plugins: ["@typescript-eslint"],
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+  ],
   ignorePatterns: ["build/**", "contract-bindings/**", "cache/**"],
   rules: {
     "@typescript-eslint/explicit-function-return-type": "error",

--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -36,9 +36,11 @@ task(TASK_COMPILE).setAction(async (_, {config}, runSuper) => {
 import {TASK_COMPILE_GET_COMPILER_INPUT} from "@nomiclabs/buidler/builtin-tasks/task-names";
 
 task(TASK_COMPILE_GET_COMPILER_INPUT).setAction(async (_, __, runSuper) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const input = await runSuper();
-  // input.settings.metadata.useLiteralContent = true;
+  // eslint-disable-next-line
   input.settings.outputSelection["*"]["*"].push("storageLayout");
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return input;
 });
 

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 import assert from "assert";
 import * as ethers from "ethers";
 import * as abi from "@ethersproject/abi";

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -38,7 +38,8 @@ function getRevertCause(error: Error): string {
 // It means that `view` functions are called on block `N`, but non-view on `N+1`.
 // It may be problematic in some tests, because they will see slightly different blockchain states.
 // This function allows a `view` function to see exactly the same state as the next non-`view` one.
-async function callOnNextBlock<T>(fn: () => T): Promise<T> {
+async function callOnNextBlock<T>(fn: () => Promise<T>): Promise<T> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const snapshot = await buidler.ethers.provider.send("evm_snapshot", []);
   await mineBlocks(1);
   const returned = await fn();

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "files": [
+    "buidler.config.ts",
+    "node_modules/@nomiclabs/buidler-ethers/src/type-extensions.d.ts",
+    ".eslintrc.js"
+  ],
+  "compilerOptions": {
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
We add all recommended lints that require type checking. This allows us to catch issues with promises.