### PR TITLE
Add nextCycle to receiver deltas

### DIFF
--- a/test/support.ts
+++ b/test/support.ts
@@ -17,8 +17,8 @@ export async function submit(
   txName = "transaction"
 ): Promise<Ethers.ContractReceipt> {
   const receipt = await (await tx).wait();
-  if (PRINT_GAS_USAGE) {
-    console.log("Gas used for " + txName + ": ", receipt.gasUsed.toString());
+  if (PRINT_GAS_USAGE || process.env.PRINT_GAS_USAGE) {
+    console.log("Gas used for " + txName + ": " + receipt.gasUsed.toString());
   }
   return receipt;
 }


### PR DESCRIPTION
Reduces gas usage when adding a receiver. It reduces edited slots per receiver from 4 to 2 when starting or stopping a payment. On the other hand it slightly increases gas usage while collecting, because more slots need to accessed.

When I have more time I need to dive deeper to understand the costs, there are many mysterious gas sinks, which I can't explain. E.g. reading a variable from a storage map costing 1000 gas. Or deletion of slots in a loop, which when commented out increases gas usage by just a few thousand instead of tens of thousands.