### PR TITLE
Encapsulate pool test utils

### DIFF
--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -23,61 +23,6 @@ import {
 
 const CYCLE_BLOCKS = 10;
 
-type AnyPool = EthPool | Erc20Pool;
-
-async function getEthPoolUsers(): Promise<EthPoolUser[]> {
-  const signers = await buidler.ethers.getSigners();
-  const pool = await new EthPoolFactory(signers[0]).deploy(CYCLE_BLOCKS);
-  await pool.deployed();
-  const poolSigners = signers.map(
-    async (signer: Signer) =>
-      <EthPoolUser>{
-        pool: pool.connect(signer),
-        addr: await signer.getAddress(),
-      }
-  );
-  return Promise.all(poolSigners);
-}
-
-interface EthPoolUser {
-  pool: EthPool;
-  addr: string;
-}
-
-async function getErc20PoolUsers(): Promise<Erc20PoolUser[]> {
-  const signers = await buidler.ethers.getSigners();
-  const signer0 = signers[0];
-  const signer0Addr = await signer0.getAddress();
-  const totalSupply = signers.length;
-  const erc20 = await new RadFactory(signer0).deploy(signer0Addr, totalSupply);
-  await erc20.deployed();
-  const pool = await new Erc20PoolFactory(signer0).deploy(
-    CYCLE_BLOCKS,
-    erc20.address
-  );
-  await pool.deployed();
-  const supplyPerUser = (await erc20.totalSupply()).div(signers.length);
-  const users = [];
-  for (const signer of signers) {
-    const addr = await signer.getAddress();
-    await erc20.transfer(addr, supplyPerUser);
-    const user = <Erc20PoolUser>{
-      pool: pool.connect(signer),
-      erc20: erc20.connect(signer),
-      addr,
-    };
-    await user.erc20.approve(user.pool.address, supplyPerUser);
-    users.push(user);
-  }
-  return users;
-}
-
-interface Erc20PoolUser {
-  pool: Erc20Pool;
-  erc20: Erc20;
-  addr: string;
-}
-
 // The next transaction will be executed on the first block of the next cycle,
 // but the next call will be executed on the last block of the current cycle
 async function mineBlocksUntilCycleEnd(): Promise<void> {
@@ -85,317 +30,365 @@ async function mineBlocksUntilCycleEnd(): Promise<void> {
   await mineBlocks(CYCLE_BLOCKS - ((blockNumber + 1) % CYCLE_BLOCKS));
 }
 
-async function collectEth(
-  pool: EthPool,
-  expectedAmount: number
-): Promise<void> {
-  await expectCollectableOnNextBlock(pool, expectedAmount);
-  const balanceBefore = await pool.signer.getBalance();
-  await submit(pool.collect({gasPrice: 0}), "collect");
-  const balanceAfter = await pool.signer.getBalance();
-  const collected = balanceAfter.sub(balanceBefore).toNumber();
-  expect(collected).to.equal(
-    expectedAmount,
-    "The collected amount is different from the expected amount"
-  );
-  await expectCollectable(pool, 0);
-}
+type AnyPool = EthPool | Erc20Pool;
 
-async function collectErc20(
-  user: Erc20PoolUser,
-  expectedAmount: number
-): Promise<void> {
-  await expectCollectableOnNextBlock(user.pool, expectedAmount);
-  const balanceBefore = await user.erc20.balanceOf(user.addr);
-  await submit(user.pool.collect(), "collect");
-  const balanceAfter = await user.erc20.balanceOf(user.addr);
-  const collected = balanceAfter.sub(balanceBefore).toNumber();
-  expect(collected).to.equal(
-    expectedAmount,
-    "The collected amount is different from the expected amount"
-  );
-  await expectCollectable(user.pool, 0);
-}
+abstract class PoolUser {
+  pool: AnyPool;
+  // The address of the user
+  addr: string;
 
-async function setAmountPerBlock(pool: AnyPool, amount: number): Promise<void> {
-  await submit(pool.setAmountPerBlock(amount), "setAmountPerBlock");
-  await expectAmountPerBlock(pool, amount);
-}
-
-async function setReceiver(
-  pool: AnyPool,
-  address: string,
-  weight: number
-): Promise<void> {
-  const receivers = await getAllReceivers(pool);
-  await submit(pool.setReceiver(address, weight), "setReceiver");
-  if (weight == 0) {
-    receivers.delete(address);
-  } else {
-    receivers.set(address, weight);
+  constructor(pool: AnyPool, addr: string) {
+    this.pool = pool;
+    this.addr = addr;
   }
-  await expectReceivers(pool, receivers);
+
+  async setAmountPerBlock(amount: number): Promise<void> {
+    await submit(this.pool.setAmountPerBlock(amount), "setAmountPerBlock");
+    await this.expectAmountPerBlock(amount);
+  }
+
+  async setReceiver(receiver: this, weight: number): Promise<void> {
+    const receivers = await this.getAllReceivers();
+    await submit(this.pool.setReceiver(receiver.addr, weight), "setReceiver");
+    if (weight == 0) {
+      receivers.delete(receiver.addr);
+    } else {
+      receivers.set(receiver.addr, weight);
+    }
+    await this.expectReceivers(receivers);
+  }
+
+  async getAllReceivers(): Promise<Map<string, number>> {
+    const receivers = await this.pool.getAllReceivers();
+    return new Map(receivers.map(({receiver, weight}) => [receiver, weight]));
+  }
+
+  async expectSetReceiverReverts(
+    receiver: this,
+    weight: number,
+    expectedCause: string
+  ): Promise<void> {
+    await submitFailing(
+      this.pool.setReceiver(receiver.addr, weight),
+      "setReceiver",
+      expectedCause
+    );
+  }
+
+  async expectCollectableOnNextBlock(amount: number): Promise<void> {
+    await callOnNextBlock(async () => {
+      await this.expectCollectable(amount);
+    });
+  }
+
+  async expectCollectable(amount: number): Promise<void> {
+    const collectable = (await this.pool.collectable()).toNumber();
+    expect(collectable).to.equal(
+      amount,
+      "The collectable amount is different from the expected amount"
+    );
+  }
+
+  async expectWithdrawableOnNextBlock(amount: number): Promise<void> {
+    await callOnNextBlock(async () => {
+      await this.expectWithdrawable(amount);
+    });
+  }
+
+  async expectWithdrawable(amount: number): Promise<void> {
+    const withdrawable = (await this.pool.withdrawable()).toNumber();
+    expect(withdrawable).to.equal(
+      amount,
+      "The withdrawable amount is different from the expected amount"
+    );
+  }
+
+  async expectAmountPerBlock(amount: number): Promise<void> {
+    const actualAmount = (await this.pool.getAmountPerBlock()).toNumber();
+    expect(actualAmount).to.equal(
+      amount,
+      "The amount per block is different from the expected amount"
+    );
+  }
+
+  async expectReceivers(receivers: Map<string, number>): Promise<void> {
+    const receiversActual = await this.getAllReceivers();
+    expect(receiversActual).to.deep.equal(
+      receivers,
+      "Unexpected receivers list"
+    );
+  }
 }
 
-async function getAllReceivers(pool: AnyPool): Promise<Map<string, number>> {
-  const receivers = await pool.getAllReceivers();
-  return new Map(receivers.map(({receiver, weight}) => [receiver, weight]));
-}
-
-async function topUpEth(
-  pool: EthPool,
-  amountFrom: number,
-  amountTo: number
-): Promise<void> {
-  await expectWithdrawableOnNextBlock(pool, amountFrom);
-  await submit(pool.topUp({value: amountTo - amountFrom}), "topUpEth");
-  await expectWithdrawable(pool, amountTo);
-}
-
-async function topUpErc20(
-  user: Erc20PoolUser,
-  amountFrom: number,
-  amountTo: number
-): Promise<void> {
-  const amount = amountTo - amountFrom;
-  const balanceBefore = await user.erc20.balanceOf(user.pool.address);
-  await expectWithdrawableOnNextBlock(user.pool, amountFrom);
-  await submit(user.pool.topUp(amount), "topUpErc20");
-  const balanceAfter = await user.erc20.balanceOf(user.pool.address);
-  const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
-  expect(withdrawn).to.equal(
-    amount,
-    "The transferred amount is different from the requested amount"
+async function getEthPoolUsers(): Promise<EthPoolUser[]> {
+  const signers = await buidler.ethers.getSigners();
+  const pool = await new EthPoolFactory(signers[0]).deploy(CYCLE_BLOCKS);
+  await pool.deployed();
+  const poolSigners = signers.map(
+    async (signer: Signer) => await EthPoolUser.new(pool, signer)
   );
-  await expectWithdrawable(user.pool, amountTo);
+  return Promise.all(poolSigners);
 }
 
-async function withdrawEth(
-  pool: EthPool,
-  amountFrom: number,
-  amountTo: number
-): Promise<void> {
-  await expectWithdrawableOnNextBlock(pool, amountFrom);
-  const amount = amountFrom - amountTo;
-  const balanceBefore = await pool.signer.getBalance();
-  await submit(pool.withdraw(amount, {gasPrice: 0}), "withdrawEth");
-  const balanceAfter = await pool.signer.getBalance();
-  const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
-  expect(withdrawn).to.equal(
-    amount,
-    "The withdrawn amount is different from the requested amount"
+class EthPoolUser extends PoolUser {
+  pool: EthPool;
+
+  constructor(pool: EthPool, addr: string) {
+    super(pool, addr);
+    this.pool = pool;
+  }
+
+  static async new(pool: EthPool, signer: Signer): Promise<EthPoolUser> {
+    return new EthPoolUser(pool.connect(signer), await signer.getAddress());
+  }
+
+  async topUp(amountFrom: number, amountTo: number): Promise<void> {
+    await this.expectWithdrawableOnNextBlock(amountFrom);
+    await submit(this.pool.topUp({value: amountTo - amountFrom}), "topUp ETH");
+    await this.expectWithdrawable(amountTo);
+  }
+
+  async withdraw(amountFrom: number, amountTo: number): Promise<void> {
+    await this.expectWithdrawableOnNextBlock(amountFrom);
+    const amount = amountFrom - amountTo;
+    const balanceBefore = await this.pool.signer.getBalance();
+    await submit(this.pool.withdraw(amount, {gasPrice: 0}), "withdraw ETH");
+    const balanceAfter = await this.pool.signer.getBalance();
+    const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
+    expect(withdrawn).to.equal(
+      amount,
+      "The withdrawn amount is different from the requested amount"
+    );
+    await this.expectWithdrawable(amountTo);
+  }
+
+  async collect(expectedAmount: number): Promise<void> {
+    await this.expectCollectableOnNextBlock(expectedAmount);
+    const balanceBefore = await this.pool.signer.getBalance();
+    await submit(this.pool.collect({gasPrice: 0}), "collect ETH");
+    const balanceAfter = await this.pool.signer.getBalance();
+    const collected = balanceAfter.sub(balanceBefore).toNumber();
+    expect(collected).to.equal(
+      expectedAmount,
+      "The collected amount is different from the expected amount"
+    );
+    await this.expectCollectable(0);
+  }
+}
+
+async function getErc20PoolUsers(): Promise<Erc20PoolUser[]> {
+  const signers = await buidler.ethers.getSigners();
+  const signer0 = signers[0];
+  const signer0Addr = await signer0.getAddress();
+
+  const totalSupply = signers.length;
+  const erc20 = await new RadFactory(signer0).deploy(signer0Addr, totalSupply);
+  await erc20.deployed();
+
+  const pool = await new Erc20PoolFactory(signer0).deploy(
+    CYCLE_BLOCKS,
+    erc20.address
   );
-  await expectWithdrawable(pool, amountTo);
+  await pool.deployed();
+
+  const supplyPerUser = (await erc20.totalSupply()).div(signers.length);
+  const users = [];
+  for (const signer of signers) {
+    const user = await Erc20PoolUser.new(pool, erc20, signer);
+    users.push(user);
+    await erc20.transfer(user.addr, supplyPerUser);
+  }
+  return users;
 }
 
-async function withdrawErc20(
-  user: Erc20PoolUser,
-  amountFrom: number,
-  amountTo: number
-): Promise<void> {
-  await expectWithdrawableOnNextBlock(user.pool, amountFrom);
-  const amount = amountFrom - amountTo;
-  const balanceBefore = await user.erc20.balanceOf(user.addr);
-  await submit(user.pool.withdraw(amount), "withdrawErc20");
-  const balanceAfter = await user.erc20.balanceOf(user.addr);
-  const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
-  expect(withdrawn).to.equal(
-    amount,
-    "The withdrawn amount is different from the requested amount"
-  );
-  await expectWithdrawable(user.pool, amountTo);
-}
+class Erc20PoolUser extends PoolUser {
+  pool: Erc20Pool;
+  erc20: Erc20;
 
-async function expectSetReceiverReverts(
-  pool: AnyPool,
-  address: string,
-  weight: number,
-  expectedCause: string
-): Promise<void> {
-  await submitFailing(
-    pool.setReceiver(address, weight),
-    "setReceiver",
-    expectedCause
-  );
-}
+  constructor(pool: Erc20Pool, erc20: Erc20, addr: string) {
+    super(pool, addr);
+    this.pool = pool;
+    this.erc20 = erc20;
+  }
 
-async function expectCollectableOnNextBlock(
-  pool: AnyPool,
-  amount: number
-): Promise<void> {
-  await callOnNextBlock(async () => {
-    await expectCollectable(pool, amount);
-  });
-}
+  static async new(
+    pool: Erc20Pool,
+    erc20: Erc20,
+    signer: Signer
+  ): Promise<Erc20PoolUser> {
+    const userErc20 = erc20.connect(signer);
+    const uint256Max = BigNumber.from(1).shl(256).sub(1);
+    await userErc20.approve(pool.address, uint256Max);
+    return new Erc20PoolUser(
+      pool.connect(signer),
+      userErc20,
+      await signer.getAddress()
+    );
+  }
 
-async function expectCollectable(pool: AnyPool, amount: number): Promise<void> {
-  const collectable = (await pool.collectable()).toNumber();
-  expect(collectable).to.equal(
-    amount,
-    "The collectable amount is different from the expected amount"
-  );
-}
+  async topUp(amountFrom: number, amountTo: number): Promise<void> {
+    const amount = amountTo - amountFrom;
+    const balanceBefore = await this.erc20.balanceOf(this.pool.address);
+    await this.expectWithdrawableOnNextBlock(amountFrom);
+    await submit(this.pool.topUp(amount), "topUp ERC-20");
+    const balanceAfter = await this.erc20.balanceOf(this.pool.address);
+    const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
+    expect(withdrawn).to.equal(
+      amount,
+      "The transferred amount is different from the requested amount"
+    );
+    await this.expectWithdrawable(amountTo);
+  }
 
-async function expectWithdrawableOnNextBlock(
-  pool: AnyPool,
-  amount: number
-): Promise<void> {
-  await callOnNextBlock(async () => {
-    await expectWithdrawable(pool, amount);
-  });
-}
+  async withdraw(amountFrom: number, amountTo: number): Promise<void> {
+    await this.expectWithdrawableOnNextBlock(amountFrom);
+    const amount = amountFrom - amountTo;
+    const balanceBefore = await this.erc20.balanceOf(this.addr);
+    await submit(this.pool.withdraw(amount), "withdraw ERC-20");
+    const balanceAfter = await this.erc20.balanceOf(this.addr);
+    const withdrawn = balanceAfter.sub(balanceBefore).toNumber();
+    expect(withdrawn).to.equal(
+      amount,
+      "The withdrawn amount is different from the requested amount"
+    );
+    await this.expectWithdrawable(amountTo);
+  }
 
-async function expectWithdrawable(
-  pool: AnyPool,
-  amount: number
-): Promise<void> {
-  const withdrawable = (await pool.withdrawable()).toNumber();
-  expect(withdrawable).to.equal(
-    amount,
-    "The withdrawable amount is different from the expected amount"
-  );
-}
-
-async function expectAmountPerBlock(
-  pool: AnyPool,
-  amount: number
-): Promise<void> {
-  const actualAmount = (await pool.getAmountPerBlock()).toNumber();
-  expect(actualAmount).to.equal(
-    amount,
-    "The amount per block is different from the expected amount"
-  );
-}
-
-async function expectReceivers(
-  pool: AnyPool,
-  receivers: Map<string, number>
-): Promise<void> {
-  const receiversActual = await getAllReceivers(pool);
-  expect(receiversActual).to.deep.equal(receivers, "Unexpected receivers list");
+  async collect(expectedAmount: number): Promise<void> {
+    await this.expectCollectableOnNextBlock(expectedAmount);
+    const balanceBefore = await this.erc20.balanceOf(this.addr);
+    await submit(this.pool.collect(), "collect ERC-20");
+    const balanceAfter = await this.erc20.balanceOf(this.addr);
+    const collected = balanceAfter.sub(balanceBefore).toNumber();
+    expect(collected).to.equal(
+      expectedAmount,
+      "The collected amount is different from the expected amount"
+    );
+    await this.expectCollectable(0);
+  }
 }
 
 describe("EthPool", function () {
   it("Sends funds from a single sender to a single receiver", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 1);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(1);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(15);
     // Sender had 16 blocks paying 1 per block
-    await withdrawEth(sender.pool, 84, 0);
+    await sender.withdraw(84, 0);
     await mineBlocksUntilCycleEnd();
     // Sender had 16 blocks paying 1 per block
-    await collectEth(receiver.pool, 16);
+    await receiver.collect(16);
   });
 
   it("Sends some funds from a single sender to two receivers", async function () {
     const [sender, receiver1, receiver2] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 2);
-    await setReceiver(sender.pool, receiver1.addr, 1);
-    await setReceiver(sender.pool, receiver2.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(2);
+    await sender.setReceiver(receiver1, 1);
+    await sender.setReceiver(receiver2, 1);
     await mineBlocks(13);
     // Sender had 15 blocks paying 2 per block
-    await withdrawEth(sender.pool, 70, 0);
+    await sender.withdraw(70, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver 1 had 1 block paying 2 per block and 14 blocks paying 1 per block
-    await collectEth(receiver1.pool, 16);
+    await receiver1.collect(16);
     // Receiver 2 had 14 blocks paying 1 per block
-    await collectEth(receiver2.pool, 14);
+    await receiver2.collect(14);
   });
 
   it("Sends some funds from a two senders to a single receiver", async function () {
     const [sender1, sender2, receiver] = await getEthPoolUsers();
-    await topUpEth(sender1.pool, 0, 100);
-    await setAmountPerBlock(sender1.pool, 1);
-    await topUpEth(sender2.pool, 0, 100);
-    await setAmountPerBlock(sender2.pool, 2);
-    await setReceiver(sender1.pool, receiver.addr, 1);
-    await setReceiver(sender2.pool, receiver.addr, 1);
+    await sender1.topUp(0, 100);
+    await sender1.setAmountPerBlock(1);
+    await sender2.topUp(0, 100);
+    await sender2.setAmountPerBlock(2);
+    await sender1.setReceiver(receiver, 1);
+    await sender2.setReceiver(receiver, 1);
     await mineBlocks(14);
     // Sender2 had 15 blocks paying 2 per block
-    await withdrawEth(sender2.pool, 70, 0);
+    await sender2.withdraw(70, 0);
     // Sender1 had 17 blocks paying 1 per block
-    await withdrawEth(sender1.pool, 83, 0);
+    await sender1.withdraw(83, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 15 blocks paying 3 per block and 2 blocks paying 1 per block
-    await collectEth(receiver.pool, 47);
+    await receiver.collect(47);
   });
 
   it("Does not require receiver to be initialized", async function () {
     const [receiver] = await getEthPoolUsers();
-    await collectEth(receiver.pool, 0);
+    await receiver.collect(0);
   });
 
   it("Allows collecting funds while they are being sent", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, CYCLE_BLOCKS + 10);
-    await setAmountPerBlock(sender.pool, 1);
+    await sender.topUp(0, CYCLE_BLOCKS + 10);
+    await sender.setAmountPerBlock(1);
     await mineBlocksUntilCycleEnd();
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.setReceiver(receiver, 1);
     await mineBlocksUntilCycleEnd();
     // Receiver had CYCLE_BLOCKS blocks paying 1 per block
-    await collectEth(receiver.pool, CYCLE_BLOCKS);
+    await receiver.collect(CYCLE_BLOCKS);
     await mineBlocks(6);
     // Sender had CYCLE_BLOCKS + 7 blocks paying 1 per block
-    await withdrawEth(sender.pool, 3, 0);
+    await sender.withdraw(3, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 7 blocks paying 1 per block
-    await collectEth(receiver.pool, 7);
+    await receiver.collect(7);
   });
 
   it("Sends funds until they run out", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 9);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(9);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(9);
     // Sender had 10 blocks paying 9 per block, funds are about to run out
-    await expectWithdrawableOnNextBlock(sender.pool, 10);
+    await sender.expectWithdrawableOnNextBlock(10);
     // Sender had 11 blocks paying 9 per block, funds have run out
     await mineBlocks(1);
-    await expectWithdrawableOnNextBlock(sender.pool, 1);
+    await sender.expectWithdrawableOnNextBlock(1);
     // Nothing more will be sent
     await mineBlocksUntilCycleEnd();
-    await collectEth(receiver.pool, 99);
-    await withdrawEth(sender.pool, 1, 0);
+    await receiver.collect(99);
+    await sender.withdraw(1, 0);
   });
 
   it("Allows topping up while sending", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 10);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(10);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(5);
     // Sender had 6 blocks paying 10 per block
-    await topUpEth(sender.pool, 40, 60);
+    await sender.topUp(40, 60);
     await mineBlocks(4);
     // Sender had 5 blocks paying 10 per block
-    await withdrawEth(sender.pool, 10, 0);
+    await sender.withdraw(10, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 11 blocks paying 10 per block
-    await collectEth(receiver.pool, 110);
+    await receiver.collect(110);
   });
 
   it("Allows topping up after funds run out", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 10);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(10);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(20);
     // Sender had 10 blocks paying 10 per block
-    await expectWithdrawable(sender.pool, 0);
+    await sender.expectWithdrawable(0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 10 blocks paying 10 per block
-    await expectCollectableOnNextBlock(receiver.pool, 100);
-    await topUpEth(sender.pool, 0, 60);
+    await receiver.expectCollectableOnNextBlock(100);
+    await sender.topUp(0, 60);
     await mineBlocks(4);
     // Sender had 5 blocks paying 10 per block
-    await withdrawEth(sender.pool, 10, 0);
+    await sender.withdraw(10, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 15 blocks paying 10 per block
-    await collectEth(receiver.pool, 150);
+    await receiver.collect(150);
   });
 
   it("Allows sending, which should end after block number 2^64", async function () {
@@ -407,138 +400,132 @@ describe("EthPool", function () {
       toppedUp.toString(),
       "The withdrawable amount is different from the expected amount"
     );
-    await setAmountPerBlock(sender.pool, 1);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.setAmountPerBlock(1);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(9);
     // Sender had 10 blocks paying 1 per block
     await sender.pool.withdraw(toppedUp.sub(10));
-    await expectWithdrawable(sender.pool, 0);
+    await sender.expectWithdrawable(0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 10 blocks paying 1 per block
-    await collectEth(receiver.pool, 10);
+    await receiver.collect(10);
   });
 
   it("Allows changing amount per block while sending", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 10);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(10);
+    await sender.setReceiver(receiver, 1);
     await mineBlocks(3);
-    await setAmountPerBlock(sender.pool, 9);
+    await sender.setAmountPerBlock(9);
     await mineBlocks(3);
     // Sender had 4 blocks paying 10 per block and 4 blocks paying 9 per block
-    await withdrawEth(sender.pool, 24, 0);
+    await sender.withdraw(24, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 4 blocks paying 10 per block and 4 blocks paying 9 per block
-    await collectEth(receiver.pool, 76);
+    await receiver.collect(76);
   });
 
   it("Sends amount per block rounded down to a multiple of weights sum", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 9);
-    await setReceiver(sender.pool, receiver.addr, 5);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(9);
+    await sender.setReceiver(receiver, 5);
     await mineBlocks(4);
     // Sender had 5 blocks paying 5 per block
-    await withdrawEth(sender.pool, 75, 0);
+    await sender.withdraw(75, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had 5 blocks paying 5 per block
-    await collectEth(receiver.pool, 25);
+    await receiver.collect(25);
   });
 
   it("Sends nothing if amount per block is smaller than weights sum", async function () {
     const [sender, receiver] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setAmountPerBlock(sender.pool, 4);
-    await setReceiver(sender.pool, receiver.addr, 5);
+    await sender.topUp(0, 100);
+    await sender.setAmountPerBlock(4);
+    await sender.setReceiver(receiver, 5);
     await mineBlocks(4);
     // Sender had no paying blocks
-    await withdrawEth(sender.pool, 100, 0);
+    await sender.withdraw(100, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver had no paying blocks
-    await collectEth(receiver.pool, 0);
+    await receiver.collect(0);
   });
 
   it("Allows changing receiver weights while sending", async function () {
     const [sender, receiver1, receiver2] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setReceiver(sender.pool, receiver1.addr, 1);
-    await setReceiver(sender.pool, receiver2.addr, 1);
-    await setAmountPerBlock(sender.pool, 12);
+    await sender.topUp(0, 100);
+    await sender.setReceiver(receiver1, 1);
+    await sender.setReceiver(receiver2, 1);
+    await sender.setAmountPerBlock(12);
     await mineBlocks(2);
-    await setReceiver(sender.pool, receiver2.addr, 2);
+    await sender.setReceiver(receiver2, 2);
     await mineBlocks(3);
     // Sender had 7 blocks paying 12 per block
-    await withdrawEth(sender.pool, 16, 0);
+    await sender.withdraw(16, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver1 had 3 blocks paying 6 per block and 4 blocks paying 4 per block
-    await collectEth(receiver1.pool, 34);
+    await receiver1.collect(34);
     // Receiver2 had 3 blocks paying 6 per block and 4 blocks paying 8 per block
-    await collectEth(receiver2.pool, 50);
+    await receiver2.collect(50);
   });
 
   it("Allows removing receivers while sending", async function () {
     const [sender, receiver1, receiver2] = await getEthPoolUsers();
-    await topUpEth(sender.pool, 0, 100);
-    await setReceiver(sender.pool, receiver1.addr, 1);
-    await setReceiver(sender.pool, receiver2.addr, 1);
-    await setAmountPerBlock(sender.pool, 10);
+    await sender.topUp(0, 100);
+    await sender.setReceiver(receiver1, 1);
+    await sender.setReceiver(receiver2, 1);
+    await sender.setAmountPerBlock(10);
     await mineBlocks(2);
-    await setReceiver(sender.pool, receiver1.addr, 0);
+    await sender.setReceiver(receiver1, 0);
     await mineBlocks(3);
-    await setReceiver(sender.pool, receiver2.addr, 0);
+    await sender.setReceiver(receiver2, 0);
     await mineBlocks(10);
     // Sender had 7 blocks paying 10 per block
-    await withdrawEth(sender.pool, 30, 0);
+    await sender.withdraw(30, 0);
     await mineBlocksUntilCycleEnd();
     // Receiver1 had 3 blocks paying 5 per block
-    await collectEth(receiver1.pool, 15);
+    await receiver1.collect(15);
     // Receiver2 had 3 blocks paying 5 per block and 4 blocks paying 10 per block
-    await collectEth(receiver2.pool, 55);
+    await receiver2.collect(55);
   });
 
   it("Limits the total weights sum", async function () {
     const [sender, receiver1, receiver2] = await getEthPoolUsers();
     const weightsSumMax = await sender.pool.SENDER_WEIGHTS_SUM_MAX();
-    await setReceiver(sender.pool, receiver1.addr, weightsSumMax);
-    await expectSetReceiverReverts(
-      sender.pool,
-      receiver2.addr,
+    await sender.setReceiver(receiver1, weightsSumMax);
+    await sender.expectSetReceiverReverts(
+      receiver2,
       1,
       "Too much total receivers weight"
     );
   });
 
   it("Limits the total receivers count", async function () {
-    const [sender] = await getEthPoolUsers();
+    const [sender, receiver] = await getEthPoolUsers();
     const weightsCountMax = await sender.pool.SENDER_WEIGHTS_COUNT_MAX();
     for (let i = 0; i < weightsCountMax; i++) {
       // This is much faster than using the `setReceiver()` test utility
       await sender.pool.setReceiver(randomAddress(), 1);
     }
-    await expectSetReceiverReverts(
-      sender.pool,
-      randomAddress(),
-      1,
-      "Too many receivers"
-    );
+    await sender.expectSetReceiverReverts(receiver, 1, "Too many receivers");
   });
 });
 
 describe("Erc20Pool", function () {
   it("Allows withdrawal of funds", async function () {
     const [sender] = await getErc20PoolUsers();
-    await topUpErc20(sender, 0, 10);
-    await withdrawErc20(sender, 10, 0);
+    await sender.topUp(0, 10);
+    await sender.withdraw(10, 0);
   });
 
   it("Allows collecting funds", async function () {
     const [sender, receiver] = await getErc20PoolUsers();
-    await topUpErc20(sender, 0, 10);
-    await setAmountPerBlock(sender.pool, 10);
-    await setReceiver(sender.pool, receiver.addr, 1);
+    await sender.topUp(0, 10);
+    await sender.setAmountPerBlock(10);
+    await sender.setReceiver(receiver, 1);
     await mineBlocksUntilCycleEnd();
-    await collectErc20(receiver, 10);
+    await receiver.collect(10);
   });
 });
 


### PR DESCRIPTION
The test tools have grown a lot recently in an organic way. Some of them require raw `address`es, some `PoolUser`s, there's also a lot of boilerplate around accessing `PoolUser`s' fields. This PR aims at cleaning it up by moving most of the tools from functions to `PoolUser`s' methods.