### PR TITLE
Rework ReceiverWeights iterator

### DIFF
--- a/contracts/PoolTest.sol
+++ b/contracts/PoolTest.sol
@@ -45,11 +45,12 @@ contract ReceiverWeightsTest {
         uint256 iterationGasUsed = 0;
         while (true) {
             // Each step of the non-pruning iteration should yield the same items
-            (address receiverIter, uint32 weightIter) = receiverWeights.nextWeight(receiver);
+            address oldReceiver = receiver;
             uint32 weight;
             uint256 gasLeftBefore = gasleft();
-            (receiver, weight) = receiverWeights.nextWeightPruning(receiver);
+            (receiver, weight) = receiverWeights.nextWeightPruning(oldReceiver);
             iterationGasUsed += gasLeftBefore - gasleft();
+            (address receiverIter, uint32 weightIter) = receiverWeights.nextWeight(oldReceiver);
             require(receiverIter == receiver, "Non-pruning iterator yielded a different receiver");
             require(weightIter == weight, "Non-pruning iterator yielded a different weight");
             if (weight == 0) break;

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -738,6 +738,30 @@ describe("ReceiverWeights", function () {
     assert(weights.length == 0);
   });
 
+  it("Allows adding items after removing all items", async function () {
+    // Add an item and then clear the list
+    const weights_test = await deployReceiverWeightsTest();
+    const [addr1] = randomAddresses();
+
+    await weights_test.setWeights([
+      {receiver: addr1, weight: 1},
+      {receiver: addr1, weight: 0},
+    ]);
+
+    assert((await weights_test.receiverWeightsSumDelta()).eq(1 - 1));
+    let weights = await weights_test.getReceiverWeightsIterated();
+    assert(weights.length == 0);
+
+    // Add an item
+    await weights_test.setWeights([{receiver: addr1, weight: 2}]);
+
+    assert((await weights_test.receiverWeightsSumDelta()).eq(2));
+    weights = await weights_test.getReceiverWeightsIterated();
+    assert(weights.length == 1);
+    assert(weights[0].receiver == addr1);
+    assert(weights[0].weight == 2);
+  });
+
   it("Allows updating the first item", async function () {
     const weights_test = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();


### PR DESCRIPTION
The first step toward https://github.com/radicle-dev/radicle-contracts/issues/16. Alters the `ReceiverWeights` iterator by making its API dependant not on weight, but on receiver address. It's also tighter with memory usage and simpler when it comes to the `view` iterator.