### PR TITLE
Add ProxyDeltas data structure

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.6.2;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./libraries/ProxyDeltas.sol";
+import "./libraries/ReceiverWeights.sol";
 
 /// @notice Funding pool contract. Automatically sends funds to a configurable set of receivers.
 ///
@@ -395,137 +397,5 @@ contract Erc20Pool is Pool {
 
     function transferToSender(uint128 amount) internal override {
         erc20.transfer(msg.sender, amount);
-    }
-}
-
-/// @notice A list of receivers to their weights, iterable and with random access
-struct ReceiverWeights {
-    mapping(address => ReceiverWeightsImpl.ReceiverWeightStored) data;
-}
-
-/// @notice Helper methods for receiver weights list.
-/// The list works optimally if after applying a series of changes it's iterated over.
-/// The list uses 1 word of storage per receiver with a non-zero weight.
-library ReceiverWeightsImpl {
-    using ReceiverWeightsImpl for ReceiverWeights;
-
-    struct ReceiverWeightStored {
-        address next;
-        uint32 weightReceiver;
-        uint32 weightProxy;
-    }
-
-    address internal constant ADDR_ROOT = address(0);
-    address internal constant ADDR_UNINITIALIZED = address(0);
-    address internal constant ADDR_END = address(1);
-
-    /// @notice Return the next non-zero receiver or proxy weight and its address.
-    /// Removes all the items that have zero receiver and proxy weights found
-    /// between the current and the next item from the list.
-    /// Iterating over the whole list prunes all the zeroed items.
-    /// @param current The previously returned receiver address or ADDR_ROOT to start iterating
-    /// @return next The next receiver address, ADDR_ROOT if the end of the list was reached
-    /// @return weightReceiver The next receiver weight, may be zero if `weightProxy` is non-zero
-    /// @return weightProxy The next proxy weight, may be zero if `weightReceiver` is non-zero
-    function nextWeightPruning(ReceiverWeights storage self, address current)
-        internal
-        returns (
-            address next,
-            uint32 weightReceiver,
-            uint32 weightProxy
-        )
-    {
-        next = self.data[current].next;
-        weightReceiver = 0;
-        weightProxy = 0;
-        if (next != ADDR_END && next != ADDR_UNINITIALIZED) {
-            weightReceiver = self.data[next].weightReceiver;
-            weightProxy = self.data[next].weightProxy;
-            // remove elements being zero
-            if (weightReceiver == 0 && weightProxy == 0) {
-                do {
-                    address newNext = self.data[next].next;
-                    // Somehow it's ~1500 gas cheaper than `delete self[next]`
-                    self.data[next].next = ADDR_UNINITIALIZED;
-                    next = newNext;
-                    if (next == ADDR_END) {
-                        // Removing the last item on the list, clear the storage
-                        if (current == ADDR_ROOT) next = ADDR_UNINITIALIZED;
-                        break;
-                    }
-                    weightReceiver = self.data[next].weightReceiver;
-                    weightProxy = self.data[next].weightProxy;
-                } while (weightReceiver == 0 && weightProxy == 0);
-                // link the previous non-zero element with the next non-zero element
-                // or ADDR_END if it became the last element on the list
-                self.data[current].next = next;
-            }
-        }
-        if (next == ADDR_END) next = ADDR_ROOT;
-    }
-
-    /// @notice Return the next non-zero receiver or proxy weight and its address.
-    /// Requires that the iterated part of the list is pruned with `nextWeightPruning`.
-    /// @param current The previously returned receiver address or ADDR_ROOT to start iterating
-    /// @return next The next receiver address, ADDR_ROOT if the end of the list was reached
-    /// @return weightReceiver The next receiver weight, may be zero if `weightProxy` is non-zero
-    /// @return weightProxy The next proxy weight, may be zero if `weightReceiver` is non-zero
-    function nextWeight(ReceiverWeights storage self, address current)
-        internal
-        view
-        returns (
-            address next,
-            uint32 weightReceiver,
-            uint32 weightProxy
-        )
-    {
-        next = self.data[current].next;
-        if (next == ADDR_END) next = ADDR_ROOT;
-        if (next != ADDR_ROOT) {
-            weightReceiver = self.data[next].weightReceiver;
-            weightProxy = self.data[next].weightProxy;
-        }
-    }
-
-    /// @notice Set weight for a specific receiver
-    /// @param receiver The receiver to set weight
-    /// @param weight The weight to set
-    /// @return previousWeight The previously set weight, may be zero
-    function setReceiverWeight(
-        ReceiverWeights storage self,
-        address receiver,
-        uint32 weight
-    ) internal returns (uint32 previousWeight) {
-        self.attachWeightToList(receiver);
-        previousWeight = self.data[receiver].weightReceiver;
-        self.data[receiver].weightReceiver = weight;
-    }
-
-    /// @notice Set weight for a specific proxy
-    /// @param proxy The proxy to set weight
-    /// @param weight The weight to set
-    /// @return previousWeight The previously set weight, may be zero
-    function setProxyWeight(
-        ReceiverWeights storage self,
-        address proxy,
-        uint32 weight
-    ) internal returns (uint32 previousWeight) {
-        self.attachWeightToList(proxy);
-        previousWeight = self.data[proxy].weightProxy;
-        self.data[proxy].weightProxy = weight;
-    }
-
-    /// @notice Ensures that weight for a specific receiver is attached to the list
-    /// @param receiver The receiver whose weight should be attached
-    function attachWeightToList(ReceiverWeights storage self, address receiver) internal {
-        require(receiver != ADDR_ROOT && receiver != ADDR_END, "Invalid receiver address");
-        // Item not attached to the list
-        if (self.data[receiver].next == ADDR_UNINITIALIZED) {
-            address rootNext = self.data[ADDR_ROOT].next;
-            self.data[ADDR_ROOT].next = receiver;
-            // The first item ever added to the list, root item not initialized yet
-            if (rootNext == ADDR_UNINITIALIZED) rootNext = ADDR_END;
-            self.data[receiver].next = rootNext;
-        }
     }
 }

--- a/contracts/libraries/ProxyDeltas.sol
+++ b/contracts/libraries/ProxyDeltas.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.2;
+
+/// @notice A list of cycles and their deltas of amounts received by a proxy.
+/// For each cycle there are stored two deltas, one for the cycle itself
+/// and one for the cycle right after it.
+/// It reduces storage access for some usage scenarios.
+/// The cycle is described by its own entry and an entry for the previous cycle.
+/// Iterable and with random access.
+struct ProxyDeltas {
+    mapping(uint64 => ProxyDeltasImpl.ProxyDeltaStored) data;
+}
+
+/// @notice Helper methods for proxy deltas list.
+/// The list works optimally if after applying a series of changes it's iterated over.
+/// The list uses 2 words of storage per stored cycle.
+library ProxyDeltasImpl {
+    struct ProxyDeltaStored {
+        uint64 next;
+        int128 thisCycleDelta;
+        // --- SLOT BOUNDARY
+        int128 nextCycleDelta;
+    }
+
+    uint64 internal constant CYCLE_ROOT = 0;
+    uint64 internal constant CYCLE_END = type(uint64).max;
+
+    /// @notice Return the next non-zero, non-obsolete delta and its cycle.
+    /// The order is undefined, it may or may not be chronological.
+    /// Prunes all the fully zeroed or obsolete items found between the current and the next cycle.
+    /// Iterating over the whole list prunes all the zeroed and obsolete items.
+    /// @param current The previously returned cycle or CYCLE_ROOT to start iterating
+    /// @param finishedCycle The last finished cycle.
+    /// Entries describing cycles before `finishedCycle` are considered obsolete.
+    /// @return next The next iterated cycle or CYCLE_ROOT if the end of the list was reached.
+    /// @return thisCycleDelta The receiver delta applied for the `next` cycle.
+    /// May be zero if `nextCycleDelta` is non-zero
+    /// @return nextCycleDelta The receiver delta applied for the cycle after the `next` cycle.
+    /// May be zero if `thisCycleDelta` is non-zero
+    function nextDeltaPruning(
+        ProxyDeltas storage self,
+        uint64 current,
+        uint64 finishedCycle
+    )
+        internal
+        returns (
+            uint64 next,
+            int128 thisCycleDelta,
+            int128 nextCycleDelta
+        )
+    {
+        next = self.data[current].next;
+        thisCycleDelta = 0;
+        nextCycleDelta = 0;
+        if (next != CYCLE_END && next != CYCLE_ROOT) {
+            thisCycleDelta = self.data[next].thisCycleDelta;
+            nextCycleDelta = self.data[next].nextCycleDelta;
+            // remove elements being zero or obsolete
+            if ((thisCycleDelta == 0 && nextCycleDelta == 0) || next < finishedCycle) {
+                do {
+                    uint64 newNext = self.data[next].next;
+                    delete self.data[next];
+                    next = newNext;
+                    if (next == CYCLE_END) {
+                        // Removing the last item on the list, clear the storage
+                        if (current == CYCLE_ROOT) {
+                            next = CYCLE_ROOT;
+                        }
+                        break;
+                    }
+                    thisCycleDelta = self.data[next].thisCycleDelta;
+                    nextCycleDelta = self.data[next].nextCycleDelta;
+                } while ((thisCycleDelta == 0 && nextCycleDelta == 0) || next < finishedCycle);
+                // link the previous non-zero element with the next non-zero element
+                // or ADDR_END if it became the last element on the list
+                self.data[current].next = next;
+            }
+        }
+        if (next == CYCLE_END) next = CYCLE_ROOT;
+    }
+
+    /// @notice Add value to the delta for a specific cycle.
+    /// @param cycle The cycle for which deltas are modified.
+    /// @param thisCycleDeltaAdded The value added to the delta for `cycle`
+    /// @param nextCycleDeltaAdded The value added to the delta for the cycle after `cycle`
+    function addToDelta(
+        ProxyDeltas storage self,
+        uint64 cycle,
+        int128 thisCycleDeltaAdded,
+        int128 nextCycleDeltaAdded
+    ) internal {
+        require(cycle != CYCLE_ROOT && cycle != CYCLE_END, "Invalid cycle number");
+        // Item not attached to the list
+        if (self.data[cycle].next == CYCLE_ROOT) {
+            uint64 rootNext = self.data[CYCLE_ROOT].next;
+            self.data[CYCLE_ROOT].next = cycle;
+            // The first item ever added to the list, root item not initialized yet
+            if (rootNext == CYCLE_ROOT) rootNext = CYCLE_END;
+            self.data[cycle].next = rootNext;
+        }
+        self.data[cycle].thisCycleDelta += thisCycleDeltaAdded;
+        self.data[cycle].nextCycleDelta += nextCycleDeltaAdded;
+    }
+}

--- a/contracts/libraries/ReceiverWeights.sol
+++ b/contracts/libraries/ReceiverWeights.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.2;
+
+/// @notice A list of receivers to their weights, iterable and with random access
+struct ReceiverWeights {
+    mapping(address => ReceiverWeightsImpl.ReceiverWeightStored) data;
+}
+
+/// @notice Helper methods for receiver weights list.
+/// The list works optimally if after applying a series of changes it's iterated over.
+/// The list uses 1 word of storage per receiver with a non-zero weight.
+library ReceiverWeightsImpl {
+    using ReceiverWeightsImpl for ReceiverWeights;
+
+    struct ReceiverWeightStored {
+        address next;
+        uint32 weightReceiver;
+        uint32 weightProxy;
+    }
+
+    address internal constant ADDR_ROOT = address(0);
+    address internal constant ADDR_END = address(1);
+
+    /// @notice Return the next non-zero receiver or proxy weight and its address.
+    /// Removes all the items that have zero receiver and proxy weights found
+    /// between the current and the next item from the list.
+    /// Iterating over the whole list prunes all the zeroed items.
+    /// @param current The previously returned receiver address or ADDR_ROOT to start iterating
+    /// @return next The next receiver address, ADDR_ROOT if the end of the list was reached
+    /// @return weightReceiver The next receiver weight, may be zero if `weightProxy` is non-zero
+    /// @return weightProxy The next proxy weight, may be zero if `weightReceiver` is non-zero
+    function nextWeightPruning(ReceiverWeights storage self, address current)
+        internal
+        returns (
+            address next,
+            uint32 weightReceiver,
+            uint32 weightProxy
+        )
+    {
+        next = self.data[current].next;
+        weightReceiver = 0;
+        weightProxy = 0;
+        if (next != ADDR_END && next != ADDR_ROOT) {
+            weightReceiver = self.data[next].weightReceiver;
+            weightProxy = self.data[next].weightProxy;
+            // remove elements being zero
+            if (weightReceiver == 0 && weightProxy == 0) {
+                do {
+                    address newNext = self.data[next].next;
+                    // Somehow it's ~1500 gas cheaper than `delete self[next]`
+                    self.data[next].next = ADDR_ROOT;
+                    next = newNext;
+                    if (next == ADDR_END) {
+                        // Removing the last item on the list, clear the storage
+                        if (current == ADDR_ROOT) next = ADDR_ROOT;
+                        break;
+                    }
+                    weightReceiver = self.data[next].weightReceiver;
+                    weightProxy = self.data[next].weightProxy;
+                } while (weightReceiver == 0 && weightProxy == 0);
+                // link the previous non-zero element with the next non-zero element
+                // or ADDR_END if it became the last element on the list
+                self.data[current].next = next;
+            }
+        }
+        if (next == ADDR_END) next = ADDR_ROOT;
+    }
+
+    /// @notice Return the next non-zero receiver or proxy weight and its address.
+    /// Requires that the iterated part of the list is pruned with `nextWeightPruning`.
+    /// @param current The previously returned receiver address or ADDR_ROOT to start iterating
+    /// @return next The next receiver address, ADDR_ROOT if the end of the list was reached
+    /// @return weightReceiver The next receiver weight, may be zero if `weightProxy` is non-zero
+    /// @return weightProxy The next proxy weight, may be zero if `weightReceiver` is non-zero
+    function nextWeight(ReceiverWeights storage self, address current)
+        internal
+        view
+        returns (
+            address next,
+            uint32 weightReceiver,
+            uint32 weightProxy
+        )
+    {
+        next = self.data[current].next;
+        if (next == ADDR_END) next = ADDR_ROOT;
+        if (next != ADDR_ROOT) {
+            weightReceiver = self.data[next].weightReceiver;
+            weightProxy = self.data[next].weightProxy;
+        }
+    }
+
+    /// @notice Set weight for a specific receiver
+    /// @param receiver The receiver to set weight
+    /// @param weight The weight to set
+    /// @return previousWeight The previously set weight, may be zero
+    function setReceiverWeight(
+        ReceiverWeights storage self,
+        address receiver,
+        uint32 weight
+    ) internal returns (uint32 previousWeight) {
+        self.attachWeightToList(receiver);
+        previousWeight = self.data[receiver].weightReceiver;
+        self.data[receiver].weightReceiver = weight;
+    }
+
+    /// @notice Set weight for a specific proxy
+    /// @param proxy The proxy to set weight
+    /// @param weight The weight to set
+    /// @return previousWeight The previously set weight, may be zero
+    function setProxyWeight(
+        ReceiverWeights storage self,
+        address proxy,
+        uint32 weight
+    ) internal returns (uint32 previousWeight) {
+        self.attachWeightToList(proxy);
+        previousWeight = self.data[proxy].weightProxy;
+        self.data[proxy].weightProxy = weight;
+    }
+
+    /// @notice Ensures that weight for a specific receiver is attached to the list
+    /// @param receiver The receiver whose weight should be attached
+    function attachWeightToList(ReceiverWeights storage self, address receiver) internal {
+        require(receiver != ADDR_ROOT && receiver != ADDR_END, "Invalid receiver address");
+        // Item not attached to the list
+        if (self.data[receiver].next == ADDR_ROOT) {
+            address rootNext = self.data[ADDR_ROOT].next;
+            self.data[ADDR_ROOT].next = receiver;
+            // The first item ever added to the list, root item not initialized yet
+            if (rootNext == ADDR_ROOT) rootNext = ADDR_END;
+            self.data[receiver].next = rootNext;
+        }
+    }
+}

--- a/test/proxy-deltas.test.ts
+++ b/test/proxy-deltas.test.ts
@@ -1,0 +1,371 @@
+import {ProxyDeltasTestFactory} from "../contract-bindings/ethers";
+import {ProxyDeltasTest} from "../contract-bindings/ethers/ProxyDeltasTest";
+import buidler from "@nomiclabs/buidler";
+import {BigNumber, BigNumberish} from "ethers";
+import {assert} from "chai";
+import {submitFailing} from "./support";
+
+async function deployProxyDeltasTest(): Promise<ProxyDeltasTest> {
+  const [signer] = await buidler.ethers.getSigners();
+  const deltasTest = await new ProxyDeltasTestFactory(signer).deploy();
+  return await deltasTest.deployed();
+}
+
+async function expectAddToDeltasWithInvalidCycleReverts(
+  deltasTest: ProxyDeltasTest,
+  finishedCycle: BigNumberish,
+  deltas: {
+    cycle: BigNumberish;
+    thisCycleDelta: BigNumberish;
+    nextCycleDelta: BigNumberish;
+  }[]
+): Promise<void> {
+  await submitFailing(
+    deltasTest.addToDeltas(finishedCycle, deltas),
+    "addToDeltas",
+    "Invalid cycle number"
+  );
+}
+
+describe("ProxyDeltas", function () {
+  it("Is empty on the beginning", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, []);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 0);
+  });
+
+  it("Keeps a single added item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(1));
+    assert(deltas[0].thisCycleDelta.eq(1));
+    assert(deltas[0].nextCycleDelta.eq(0));
+  });
+
+  it("Keeps multiple added items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 3);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(2));
+    assert(deltas[1].thisCycleDelta.eq(2));
+    assert(deltas[1].nextCycleDelta.eq(0));
+    assert(deltas[2].cycle.eq(1));
+    assert(deltas[2].thisCycleDelta.eq(1));
+    assert(deltas[2].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing the last item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 1, thisCycleDelta: -1, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 2);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(2));
+    assert(deltas[1].thisCycleDelta.eq(2));
+    assert(deltas[1].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing two last items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 1, thisCycleDelta: -1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: -2, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing the first item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: -4, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 2);
+    assert(deltas[0].cycle.eq(2));
+    assert(deltas[0].thisCycleDelta.eq(2));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(1));
+    assert(deltas[1].thisCycleDelta.eq(1));
+    assert(deltas[1].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing two first items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: -2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: -4, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(1));
+    assert(deltas[0].thisCycleDelta.eq(1));
+    assert(deltas[0].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing the middle item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: -2, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 2);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(1));
+    assert(deltas[1].thisCycleDelta.eq(1));
+    assert(deltas[1].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing two middle items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 4, thisCycleDelta: 8, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: -2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: -4, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 2);
+    assert(deltas[0].cycle.eq(4));
+    assert(deltas[0].thisCycleDelta.eq(8));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(1));
+    assert(deltas[1].thisCycleDelta.eq(1));
+    assert(deltas[1].nextCycleDelta.eq(0));
+  });
+
+  it("Allows removing all items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 1, thisCycleDelta: -1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: -2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: -4, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 0);
+  });
+
+  it("Allows adding items after removing all items", async function () {
+    // Add an item and then clear the list
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 1, thisCycleDelta: -1, nextCycleDelta: 0},
+    ]);
+
+    let deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 0);
+
+    // Add an item
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 2, nextCycleDelta: 0},
+    ]);
+
+    deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(1));
+    assert(deltas[0].thisCycleDelta.eq(2));
+    assert(deltas[0].nextCycleDelta.eq(0));
+  });
+
+  it("Allows updating the first item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 8, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 3);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(12));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(2));
+    assert(deltas[1].thisCycleDelta.eq(2));
+    assert(deltas[1].nextCycleDelta.eq(0));
+    assert(deltas[2].cycle.eq(1));
+    assert(deltas[2].thisCycleDelta.eq(1));
+    assert(deltas[2].nextCycleDelta.eq(0));
+  });
+
+  it("Allows updating the middle item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 8, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 3);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(2));
+    assert(deltas[1].thisCycleDelta.eq(10));
+    assert(deltas[1].nextCycleDelta.eq(0));
+    assert(deltas[2].cycle.eq(1));
+    assert(deltas[2].thisCycleDelta.eq(1));
+    assert(deltas[2].nextCycleDelta.eq(0));
+  });
+
+  it("Allows updating the last item", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 1, thisCycleDelta: 8, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 3);
+    assert(deltas[0].cycle.eq(3));
+    assert(deltas[0].thisCycleDelta.eq(4));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(2));
+    assert(deltas[1].thisCycleDelta.eq(2));
+    assert(deltas[1].nextCycleDelta.eq(0));
+    assert(deltas[2].cycle.eq(1));
+    assert(deltas[2].thisCycleDelta.eq(9));
+    assert(deltas[2].nextCycleDelta.eq(0));
+  });
+
+  it("Rejects adding delta for cycle 0", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+    await expectAddToDeltasWithInvalidCycleReverts(deltasTest, 0, [
+      {cycle: 0, thisCycleDelta: 1, nextCycleDelta: 0},
+    ]);
+  });
+
+  it("Rejects adding delta for cycle uint64 max", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+    const uint64Max = BigNumber.from(2).pow(64).sub(1);
+    await expectAddToDeltasWithInvalidCycleReverts(deltasTest, 0, [
+      {cycle: uint64Max, thisCycleDelta: 1, nextCycleDelta: 0},
+    ]);
+  });
+
+  it("Keeps items with only next delta set", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 0, nextCycleDelta: 1},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(1));
+    assert(deltas[0].thisCycleDelta.eq(0));
+    assert(deltas[0].nextCycleDelta.eq(1));
+  });
+
+  it("Allows removing items with only next delta set", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(0, [
+      {cycle: 1, thisCycleDelta: 0, nextCycleDelta: 1},
+      {cycle: 2, thisCycleDelta: 0, nextCycleDelta: 2},
+      {cycle: 1, thisCycleDelta: 0, nextCycleDelta: -1},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 1);
+    assert(deltas[0].cycle.eq(2));
+    assert(deltas[0].thisCycleDelta.eq(0));
+    assert(deltas[0].nextCycleDelta.eq(2));
+  });
+
+  it("Removes obsolete items", async function () {
+    const deltasTest = await deployProxyDeltasTest();
+
+    await deltasTest.addToDeltas(3, [
+      {cycle: 1, thisCycleDelta: 1, nextCycleDelta: 0},
+      {cycle: 2, thisCycleDelta: 2, nextCycleDelta: 0},
+      {cycle: 3, thisCycleDelta: 4, nextCycleDelta: 0},
+      {cycle: 4, thisCycleDelta: 8, nextCycleDelta: 0},
+      {cycle: 5, thisCycleDelta: 16, nextCycleDelta: 0},
+    ]);
+
+    const deltas = await deltasTest.getProxyDeltasIterated();
+    assert(deltas.length == 3);
+    assert(deltas[0].cycle.eq(5));
+    assert(deltas[0].thisCycleDelta.eq(16));
+    assert(deltas[0].nextCycleDelta.eq(0));
+    assert(deltas[1].cycle.eq(4));
+    assert(deltas[1].thisCycleDelta.eq(8));
+    assert(deltas[1].nextCycleDelta.eq(0));
+    assert(deltas[2].cycle.eq(3));
+    assert(deltas[2].thisCycleDelta.eq(4));
+    assert(deltas[2].nextCycleDelta.eq(0));
+  });
+});

--- a/test/receiver-weights.test.ts
+++ b/test/receiver-weights.test.ts
@@ -7,13 +7,12 @@ import {numberToAddress, randomAddresses, submitFailing} from "./support";
 
 async function deployReceiverWeightsTest(): Promise<ReceiverWeightsTest> {
   const [signer] = await buidler.ethers.getSigners();
-  return new ReceiverWeightsTestFactory(signer)
-    .deploy()
-    .then((weights) => weights.deployed());
+  const weightsTest = await new ReceiverWeightsTestFactory(signer).deploy();
+  return await weightsTest.deployed();
 }
 
 async function expectSetWeightsWithInvalidAddressReverts(
-  weights_test: ReceiverWeightsTest,
+  weightsTest: ReceiverWeightsTest,
   weights: {
     receiver: string;
     weightReceiver: BigNumberish;
@@ -21,7 +20,7 @@ async function expectSetWeightsWithInvalidAddressReverts(
   }[]
 ): Promise<void> {
   await submitFailing(
-    weights_test.setWeights(weights),
+    weightsTest.setWeights(weights),
     "setWeights",
     "Invalid receiver address"
   );
@@ -29,27 +28,27 @@ async function expectSetWeightsWithInvalidAddressReverts(
 
 describe("ReceiverWeights", function () {
   it("Is empty on the beginning", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
 
-    await weights_test.setWeights([]);
+    await weightsTest.setWeights([]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(0));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(0));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 0);
   });
 
   it("Keeps a single added item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr1);
     assert(weights[0].weightReceiver == 1);
@@ -57,18 +56,18 @@ describe("ReceiverWeights", function () {
   });
 
   it("Keeps multiple added items", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 3);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -82,19 +81,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing the last item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr1, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 2);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -105,10 +104,10 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing two last items", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
@@ -116,9 +115,9 @@ describe("ReceiverWeights", function () {
       {receiver: addr2, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 - 2));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 - 2));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -126,19 +125,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing the first item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr3, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 4));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 4));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 2);
     assert(weights[0].receiver == addr2);
     assert(weights[0].weightReceiver == 2);
@@ -149,10 +148,10 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing two first items", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
@@ -160,9 +159,9 @@ describe("ReceiverWeights", function () {
       {receiver: addr3, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2 - 4));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2 - 4));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr1);
     assert(weights[0].weightReceiver == 1);
@@ -170,19 +169,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing the middle item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr2, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 2);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -193,10 +192,10 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing two middle items", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3, addr4] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
@@ -206,10 +205,10 @@ describe("ReceiverWeights", function () {
     ]);
 
     assert(
-      (await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 + 8 - 2 - 4)
+      (await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 + 8 - 2 - 4)
     );
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 2);
     assert(weights[0].receiver == addr4);
     assert(weights[0].weightReceiver == 8);
@@ -220,10 +219,10 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing all items", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
@@ -233,36 +232,36 @@ describe("ReceiverWeights", function () {
     ]);
 
     assert(
-      (await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 - 2 - 4)
+      (await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 - 2 - 4)
     );
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 0);
   });
 
   it("Allows adding items after removing all items", async function () {
     // Add an item and then clear the list
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr1, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 - 1));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    let weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 - 1));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    let weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 0);
 
     // Add an item
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 2, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(2));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(2));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr1);
     assert(weights[0].weightReceiver == 2);
@@ -270,19 +269,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows updating the first item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr3, weightReceiver: 8, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 4 + 8));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 4 + 8));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 3);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 8);
@@ -296,19 +295,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows updating the middle item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr2, weightReceiver: 8, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2 + 8));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 2 + 8));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 3);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -322,19 +321,19 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows updating the last item", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2, addr3] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 1, weightProxy: 0},
       {receiver: addr2, weightReceiver: 2, weightProxy: 0},
       {receiver: addr3, weightReceiver: 4, weightProxy: 0},
       {receiver: addr1, weightReceiver: 8, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 + 8));
-    assert((await weights_test.weightProxySumDelta()).eq(0));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(1 + 2 + 4 - 1 + 8));
+    assert((await weightsTest.weightProxySumDelta()).eq(0));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 3);
     assert(weights[0].receiver == addr3);
     assert(weights[0].weightReceiver == 4);
@@ -348,30 +347,30 @@ describe("ReceiverWeights", function () {
   });
 
   it("Rejects setting weight for address 0", async function () {
-    const weights_test = await deployReceiverWeightsTest();
-    await expectSetWeightsWithInvalidAddressReverts(weights_test, [
+    const weightsTest = await deployReceiverWeightsTest();
+    await expectSetWeightsWithInvalidAddressReverts(weightsTest, [
       {receiver: numberToAddress(0), weightReceiver: 1, weightProxy: 0},
     ]);
   });
 
   it("Rejects setting weight for address 1", async function () {
-    const weights_test = await deployReceiverWeightsTest();
-    await expectSetWeightsWithInvalidAddressReverts(weights_test, [
+    const weightsTest = await deployReceiverWeightsTest();
+    await expectSetWeightsWithInvalidAddressReverts(weightsTest, [
       {receiver: numberToAddress(1), weightReceiver: 1, weightProxy: 0},
     ]);
   });
 
   it("Keeps items with only proxy weights set", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 0, weightProxy: 1},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(0));
-    assert((await weights_test.weightProxySumDelta()).eq(1));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(0));
+    assert((await weightsTest.weightProxySumDelta()).eq(1));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr1);
     assert(weights[0].weightReceiver == 0);
@@ -379,18 +378,18 @@ describe("ReceiverWeights", function () {
   });
 
   it("Allows removing items with only proxy weights set", async function () {
-    const weights_test = await deployReceiverWeightsTest();
+    const weightsTest = await deployReceiverWeightsTest();
     const [addr1, addr2] = randomAddresses();
 
-    await weights_test.setWeights([
+    await weightsTest.setWeights([
       {receiver: addr1, weightReceiver: 0, weightProxy: 1},
       {receiver: addr2, weightReceiver: 0, weightProxy: 2},
       {receiver: addr1, weightReceiver: 0, weightProxy: 0},
     ]);
 
-    assert((await weights_test.weightReceiverSumDelta()).eq(0));
-    assert((await weights_test.weightProxySumDelta()).eq(1 + 2 - 1));
-    const weights = await weights_test.getReceiverWeightsIterated();
+    assert((await weightsTest.weightReceiverSumDelta()).eq(0));
+    assert((await weightsTest.weightProxySumDelta()).eq(1 + 2 - 1));
+    const weights = await weightsTest.getReceiverWeightsIterated();
     assert(weights.length == 1);
     assert(weights[0].receiver == addr2);
     assert(weights[0].weightReceiver == 0);


### PR DESCRIPTION
Adds `ProxyDeltas`, which is a random access, iterable mapping between cycles and deltas of funds received by a proxy. It will be used when updating a proxy to determine how to update the downstream receivers' delta. It's an iterable version of a receiver's list of deltas, it stores the same data. Implementation and tests are a slightly modified version of the `ReceiverWeights` linked list. Some form of generics would be great in Solidity :shrug: `ProxyDeltas` aren't used in the production code yet, the next PR will do that, this PR is already quite big.