### PR TITLE
Make non-pruning weights iterator skip zeroed items

### DIFF
--- a/contracts/PoolTest.sol
+++ b/contracts/PoolTest.sol
@@ -59,19 +59,16 @@ contract ReceiverWeightsTest {
         uint256 iterationGasUsed = 0;
         while (true) {
             // Each step of the non-pruning iteration should yield the same items
-            address oldReceiver = receiver;
-            uint32 weightReceiver;
-            uint32 weightProxy;
-            uint256 gasLeftBefore = gasleft();
-            (receiver, weightReceiver, weightProxy) = receiverWeights.nextWeightPruning(
-                oldReceiver
-            );
-            iterationGasUsed += gasLeftBefore - gasleft();
             (
                 address receiverIter,
                 uint32 weightReceiverIter,
                 uint32 weightProxyIter
-            ) = receiverWeights.nextWeight(oldReceiver);
+            ) = receiverWeights.nextWeight(receiver);
+            uint32 weightReceiver;
+            uint32 weightProxy;
+            uint256 gasLeftBefore = gasleft();
+            (receiver, weightReceiver, weightProxy) = receiverWeights.nextWeightPruning(receiver);
+            iterationGasUsed += gasLeftBefore - gasleft();
             require(receiverIter == receiver, "Non-pruning iterator yielded a different receiver");
             require(
                 weightReceiverIter == weightReceiver,

--- a/contracts/libraries/ReceiverWeights.sol
+++ b/contracts/libraries/ReceiverWeights.sol
@@ -67,7 +67,6 @@ library ReceiverWeightsImpl {
     }
 
     /// @notice Return the next non-zero receiver or proxy weight and its address.
-    /// Requires that the iterated part of the list is pruned with `nextWeightPruning`.
     /// @param current The previously returned receiver address or ADDR_ROOT to start iterating
     /// @return next The next receiver address, ADDR_ROOT if the end of the list was reached
     /// @return weightReceiver The next receiver weight, may be zero if `weightProxy` is non-zero
@@ -82,11 +81,20 @@ library ReceiverWeightsImpl {
         )
     {
         next = self.data[current].next;
-        if (next == ADDR_END) next = ADDR_ROOT;
-        if (next != ADDR_ROOT) {
+        weightReceiver = 0;
+        weightProxy = 0;
+        if (next != ADDR_END && next != ADDR_ROOT) {
             weightReceiver = self.data[next].weightReceiver;
             weightProxy = self.data[next].weightProxy;
+            // skip elements being zero
+            while (weightReceiver == 0 && weightProxy == 0) {
+                next = self.data[next].next;
+                if (next == ADDR_END) break;
+                weightReceiver = self.data[next].weightReceiver;
+                weightProxy = self.data[next].weightProxy;
+            }
         }
+        if (next == ADDR_END) next = ADDR_ROOT;
     }
 
     /// @notice Set weight for a specific receiver

--- a/test/pool.test.ts
+++ b/test/pool.test.ts
@@ -448,6 +448,22 @@ describe("EthPool", function () {
     await receiver.collect(0);
   });
 
+  it("Allows removing the last receiver weight when amount per block is zero", async function () {
+    const [sender, receiver1, receiver2] = await getEthPoolUsers();
+    await sender.topUp(0, 100);
+    await sender.setReceiver(receiver1, 1);
+    await sender.setReceiver(receiver2, 1);
+    await sender.setReceiver(receiver2, 0);
+    await sender.setAmountPerBlock(12);
+    // Sender had 1 blocks paying 12 per block
+    await sender.withdraw(88, 0);
+    await mineBlocksUntilCycleEnd();
+    // Receiver1 had 1 blocks paying 12 per block
+    await receiver1.collect(12);
+    // Receiver2 had 0 paying blocks
+    await receiver2.expectCollectable(0);
+  });
+
   it("Allows changing receiver weights while sending", async function () {
     const [sender, receiver1, receiver2] = await getEthPoolUsers();
     await sender.topUp(0, 100);


### PR DESCRIPTION
Reverts the recent simplification of the non-pruning receiver weights iterator. The weights aren't guaranteed to be always pruned, it's a horrible coincidence that no tests caught it :grimacing: 