### PR TITLE
Cheaperators

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -730,6 +730,7 @@ abstract contract Pool {
 
         // Iterating over deltas, see `ProxyDeltas` for details
         uint64 cycle = ProxyDeltasImpl.CYCLE_ROOT;
+        uint64 cycleHint = ProxyDeltasImpl.CYCLE_ROOT;
         uint64 finishedCycle = blockNumber / cycleBlocks;
         uint64 currCycle = finishedCycle + 1;
         // The sum of all the future changes to the per-block amount the proxy receives.
@@ -740,10 +741,9 @@ abstract contract Pool {
         while (true) {
             int128 thisCycleDelta;
             int128 nextCycleDelta;
-            (cycle, thisCycleDelta, nextCycleDelta) = proxy.amtPerWeightDeltas.nextDeltaPruning(
-                cycle,
-                finishedCycle
-            );
+            (cycle, cycleHint, thisCycleDelta, nextCycleDelta) = proxy
+                .amtPerWeightDeltas
+                .nextDeltaPruning(cycle, cycleHint, finishedCycle);
             if (cycle == ProxyDeltasImpl.CYCLE_ROOT) break;
             // `thisCycleDelta` from the previously finished cycle is irrelevant
             if (cycle == finishedCycle) thisCycleDelta = 0;

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -451,10 +451,14 @@ abstract contract Pool {
         uint32 weightsCount = 0;
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiver = ReceiverWeightsImpl.ADDR_ROOT;
+        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 receiverWeight;
             uint32 proxyWeight;
-            (receiver, receiverWeight, proxyWeight) = sender.receiverWeights.nextWeight(receiver);
+            (receiver, hint, receiverWeight, proxyWeight) = sender.receiverWeights.nextWeight(
+                receiver,
+                hint
+            );
             if (receiver == ReceiverWeightsImpl.ADDR_ROOT) break;
             weightsSparse[weightsCount++] = ReceiverProxyWeight(
                 receiver,
@@ -506,9 +510,10 @@ abstract contract Pool {
         uint32 weightsCount = 0;
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiver = ReceiverWeightsImpl.ADDR_ROOT;
+        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 weight;
-            (receiver, weight, ) = proxy.receiverWeights.nextWeight(receiver);
+            (receiver, hint, weight, ) = proxy.receiverWeights.nextWeight(receiver, hint);
             if (receiver == ReceiverWeightsImpl.ADDR_ROOT) break;
             weightsSparse[weightsCount++] = ReceiverWeight(receiver, weight);
         }
@@ -579,12 +584,13 @@ abstract contract Pool {
         Sender storage sender = senders[msg.sender];
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiverAddr = ReceiverWeightsImpl.ADDR_ROOT;
+        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 receiverWeight;
             uint32 proxyWeight;
-            (receiverAddr, receiverWeight, proxyWeight) = sender.receiverWeights.nextWeightPruning(
-                receiverAddr
-            );
+            (receiverAddr, hint, receiverWeight, proxyWeight) = sender
+                .receiverWeights
+                .nextWeightPruning(receiverAddr, hint);
             if (receiverAddr == ReceiverWeightsImpl.ADDR_ROOT) break;
             if (receiverWeight != 0) {
                 int128 perBlockDelta = receiverWeight * amtPerWeightPerBlockDelta;
@@ -615,9 +621,10 @@ abstract contract Pool {
         updateSingleProxyDelta(proxy.amtPerWeightDeltas, blockEnd, -perBlockPerProxyWeightDelta);
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiver = ReceiverWeightsImpl.ADDR_ROOT;
+        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 weight;
-            (receiver, weight, ) = proxy.receiverWeights.nextWeightPruning(receiver);
+            (receiver, hint, weight, ) = proxy.receiverWeights.nextWeightPruning(receiver, hint);
             if (receiver == ReceiverWeightsImpl.ADDR_ROOT) break;
             setReceiverDeltaFromNow(receiver, perBlockPerProxyWeightDelta * weight, blockEnd);
         }
@@ -707,9 +714,13 @@ abstract contract Pool {
         ReceiverWeight[] memory receiversList = new ReceiverWeight[](PROXY_WEIGHTS_COUNT_MAX);
         // Iterating over receivers, see `ReceiverWeights` for details
         address receiverAddr = ReceiverWeightsImpl.ADDR_ROOT;
+        address receiverHint = ReceiverWeightsImpl.ADDR_ROOT;
         while (true) {
             uint32 weight;
-            (receiverAddr, weight, ) = proxy.receiverWeights.nextWeightPruning(receiverAddr);
+            (receiverAddr, receiverHint, weight, ) = proxy.receiverWeights.nextWeightPruning(
+                receiverAddr,
+                receiverHint
+            );
             if (receiverAddr == ReceiverWeightsImpl.ADDR_ROOT) break;
             require(receiversCount < PROXY_WEIGHTS_COUNT_MAX, "Too many proxy receivers");
             receiversList[receiversCount++] = ReceiverWeight(receiverAddr, weight);

--- a/contracts/PoolTest.sol
+++ b/contracts/PoolTest.sol
@@ -58,17 +58,26 @@ contract ReceiverWeightsTest {
         }
         delete receiverWeightsIterated;
         address receiver = ReceiverWeightsImpl.ADDR_ROOT;
+        address hint = ReceiverWeightsImpl.ADDR_ROOT;
         uint256 iterationGasUsed = 0;
         while (true) {
             // Each step of the non-pruning iteration should yield the same items
-            (address receiverIter, uint32 weightReceiverIter, uint32 weightProxyIter) =
-                receiverWeights.nextWeight(receiver);
+            (
+                address receiverIter,
+                address hintIter,
+                uint32 weightReceiverIter,
+                uint32 weightProxyIter
+            ) = receiverWeights.nextWeight(receiver, hint);
             uint32 weightReceiver;
             uint32 weightProxy;
             uint256 gasLeftBefore = gasleft();
-            (receiver, weightReceiver, weightProxy) = receiverWeights.nextWeightPruning(receiver);
+            (receiver, hint, weightReceiver, weightProxy) = receiverWeights.nextWeightPruning(
+                receiver,
+                hint
+            );
             iterationGasUsed += gasLeftBefore - gasleft();
             require(receiverIter == receiver, "Non-pruning iterator yielded a different receiver");
+            require(hintIter == hint, "Non-pruning iterator yielded a different next receiver");
             require(
                 weightReceiverIter == weightReceiver,
                 "Non-pruning iterator yielded a different receiver weight"

--- a/contracts/PoolTest.sol
+++ b/contracts/PoolTest.sol
@@ -147,13 +147,15 @@ contract ProxyDeltasTest {
         }
         delete proxyDeltasIterated;
         uint64 cycle = ProxyDeltasImpl.CYCLE_ROOT;
+        uint64 hint = ProxyDeltasImpl.CYCLE_ROOT;
         uint256 gasUsed = 0;
         while (true) {
             int128 thisCycleDelta;
             int128 nextCycleDelta;
             uint256 gasLeftBefore = gasleft();
-            (cycle, thisCycleDelta, nextCycleDelta) = proxyDeltas.nextDeltaPruning(
+            (cycle, hint, thisCycleDelta, nextCycleDelta) = proxyDeltas.nextDeltaPruning(
                 cycle,
+                hint,
                 finishedCycle
             );
             gasUsed += gasLeftBefore - gasleft();

--- a/contracts/libraries/ProxyDeltas.sol
+++ b/contracts/libraries/ProxyDeltas.sol
@@ -15,68 +15,63 @@ struct ProxyDeltas {
 /// The list works optimally if after applying a series of changes it's iterated over.
 /// The list uses 2 words of storage per stored cycle.
 library ProxyDeltasImpl {
+    using ProxyDeltasImpl for ProxyDeltas;
+
     struct ProxyDeltaStored {
         uint64 next;
         int128 thisCycleDelta;
+        bool isAttached;
+        // Unused. Hints the compiler that it has full control over the content
+        // of the whole storage slot and allows it to optimize more aggressively.
+        uint56 slotFiller1;
         // --- SLOT BOUNDARY
         int128 nextCycleDelta;
+        // Unused. Hints the compiler that it has full control over the content
+        // of the whole storage slot and allows it to optimize more aggressively.
+        uint128 slotFiller2;
     }
 
     uint64 internal constant CYCLE_ROOT = 0;
-    uint64 internal constant CYCLE_END = type(uint64).max;
 
     /// @notice Return the next non-zero, non-obsolete delta and its cycle.
     /// The order is undefined, it may or may not be chronological.
     /// Prunes all the fully zeroed or obsolete items found between the current and the next cycle.
     /// Iterating over the whole list prunes all the zeroed and obsolete items.
-    /// @param current The previously returned cycle or CYCLE_ROOT to start iterating
+    /// @param prevCycle The previously returned `cycle` or CYCLE_ROOT to start iterating
+    /// @param prevCycleHint The previously returned `cycleHint` or CYCLE_ROOT to start iterating
     /// @param finishedCycle The last finished cycle.
     /// Entries describing cycles before `finishedCycle` are considered obsolete.
-    /// @return next The next iterated cycle or CYCLE_ROOT if the end of the list was reached.
+    /// @return cycle The next iterated cycle or CYCLE_ROOT if the end of the list was reached.
+    /// @return cycleHint A value passed as `prevCycleHint` on the next call
     /// @return thisCycleDelta The receiver delta applied for the `next` cycle.
     /// May be zero if `nextCycleDelta` is non-zero
     /// @return nextCycleDelta The receiver delta applied for the cycle after the `next` cycle.
     /// May be zero if `thisCycleDelta` is non-zero
     function nextDeltaPruning(
         ProxyDeltas storage self,
-        uint64 current,
+        uint64 prevCycle,
+        uint64 prevCycleHint,
         uint64 finishedCycle
     )
         internal
         returns (
-            uint64 next,
+            uint64 cycle,
+            uint64 cycleHint,
             int128 thisCycleDelta,
             int128 nextCycleDelta
         )
     {
-        next = self.data[current].next;
-        thisCycleDelta = 0;
-        nextCycleDelta = 0;
-        if (next != CYCLE_END && next != CYCLE_ROOT) {
-            thisCycleDelta = self.data[next].thisCycleDelta;
-            nextCycleDelta = self.data[next].nextCycleDelta;
-            // remove elements being zero or obsolete
-            if ((thisCycleDelta == 0 && nextCycleDelta == 0) || next < finishedCycle) {
-                do {
-                    uint64 newNext = self.data[next].next;
-                    delete self.data[next];
-                    next = newNext;
-                    if (next == CYCLE_END) {
-                        // Removing the last item on the list, clear the storage
-                        if (current == CYCLE_ROOT) {
-                            next = CYCLE_ROOT;
-                        }
-                        break;
-                    }
-                    thisCycleDelta = self.data[next].thisCycleDelta;
-                    nextCycleDelta = self.data[next].nextCycleDelta;
-                } while ((thisCycleDelta == 0 && nextCycleDelta == 0) || next < finishedCycle);
-                // link the previous non-zero element with the next non-zero element
-                // or ADDR_END if it became the last element on the list
-                self.data[current].next = next;
-            }
+        if (prevCycle == CYCLE_ROOT) prevCycleHint = self.data[CYCLE_ROOT].next;
+        cycle = prevCycleHint;
+        while (cycle != CYCLE_ROOT) {
+            thisCycleDelta = self.data[cycle].thisCycleDelta;
+            nextCycleDelta = self.data[cycle].nextCycleDelta;
+            cycleHint = self.data[cycle].next;
+            if ((thisCycleDelta != 0 || nextCycleDelta != 0) && cycle >= finishedCycle) break;
+            delete self.data[cycle];
+            cycle = cycleHint;
         }
-        if (next == CYCLE_END) next = CYCLE_ROOT;
+        if (cycle != prevCycleHint) self.data[prevCycle].next = cycle;
     }
 
     /// @notice Add value to the delta for a specific cycle.
@@ -89,16 +84,20 @@ library ProxyDeltasImpl {
         int128 thisCycleDeltaAdded,
         int128 nextCycleDeltaAdded
     ) internal {
-        require(cycle != CYCLE_ROOT && cycle != CYCLE_END, "Invalid cycle number");
-        // Item not attached to the list
-        if (self.data[cycle].next == CYCLE_ROOT) {
-            uint64 rootNext = self.data[CYCLE_ROOT].next;
-            self.data[CYCLE_ROOT].next = cycle;
-            // The first item ever added to the list, root item not initialized yet
-            if (rootNext == CYCLE_ROOT) rootNext = CYCLE_END;
-            self.data[cycle].next = rootNext;
-        }
+        self.attachToList(cycle);
         self.data[cycle].thisCycleDelta += thisCycleDeltaAdded;
         self.data[cycle].nextCycleDelta += nextCycleDeltaAdded;
+    }
+
+    /// @notice Ensures that the delta for a specific cycle is attached to the list
+    /// @param cycle The cycle for which delta should be attached
+    function attachToList(ProxyDeltas storage self, uint64 cycle) internal {
+        require(cycle != CYCLE_ROOT && cycle != type(uint64).max, "Invalid cycle number");
+        if (!self.data[cycle].isAttached) {
+            uint64 rootNext = self.data[CYCLE_ROOT].next;
+            self.data[CYCLE_ROOT].next = cycle;
+            self.data[cycle].next = rootNext;
+            self.data[cycle].isAttached = true;
+        }
     }
 }

--- a/test/receiver-weights.test.ts
+++ b/test/receiver-weights.test.ts
@@ -355,13 +355,6 @@ describe("ReceiverWeights", function () {
     ]);
   });
 
-  it("Rejects setting weight for address 1", async function () {
-    const weightsTest = await deployReceiverWeightsTest();
-    await expectSetWeightsWithInvalidAddressReverts(weightsTest, [
-      { receiver: numberToAddress(1), weightReceiver: 1, weightProxy: 0 },
-    ]);
-  });
-
   it("Keeps items with only proxy weights set", async function () {
     const weightsTest = await deployReceiverWeightsTest();
     const [addr1] = randomAddresses();


### PR DESCRIPTION
Cuts 20-33 % of gas cost of iterating over mappings. The larger the mapping the bigger the saving.

Unfortunately it makes the iteration API even more complex. I've tried wrapping the swarm of parameters in a structure, but that forced it to be stored in memory leading to a considerable cost increase.