### PR TITLE
Move @uniswap and @ensdomains to "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "license": "GPL-3.0-only",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "@ensdomains/ens": "^0.4.5",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0"
+  },
+  "devDependencies": {
     "@ethersproject/abi": "^5.0.9",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@openzeppelin/contracts": "^3.3.0-solc-0.7",
@@ -16,7 +18,6 @@
     "@types/mocha": "^8.2.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
-    "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "chai": "^4.2.0",
     "eslint": "^7.17.0",
     "ethers": "^5.0.24",


### PR DESCRIPTION
These are not available in the exported build that clients use, requiring
"all" clients to add these exact dependencies themselves in order to run
the 'deploy.ts' script. That should happen here instead to that it can
actually offer the functionality it proposes.