### PR TITLE
add permit to RadicleToken and change Registry to commit reveal scheme

### DIFF
--- a/contracts/Governance/RadicleToken.sol
+++ b/contracts/Governance/RadicleToken.sol
@@ -70,6 +70,9 @@ contract RadicleToken {
     bytes32 public constant DELEGATION_TYPEHASH =
         keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
 
+    /// @notice The EIP-712 typehash for EIP-2612 permit
+    bytes32 public constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     /// @notice A record of states for signing / validating signatures
     mapping(address => uint256) public nonces;
 
@@ -117,6 +120,13 @@ contract RadicleToken {
         return DECIMALS;
     }
 
+    /* @notice DOMAIN_SEPARATOR */
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(NAME)), getChainId(), address(this))
+        );
+    }
+
     /**
      * @notice Get the number of tokens `spender` is approved to spend on behalf of `account`
      * @param account The address of the account holding the funds
@@ -136,6 +146,11 @@ contract RadicleToken {
      * @return Whether or not the approval succeeded
      */
     function approve(address spender, uint256 rawAmount) external returns (bool) {
+        _approve(msg.sender, spender, rawAmount);
+        return true;
+    }
+
+    function _approve(address owner, address spender, uint256 rawAmount) internal {
         uint96 amount;
         if (rawAmount == uint256(-1)) {
             amount = uint96(-1);
@@ -143,10 +158,9 @@ contract RadicleToken {
             amount = safe96(rawAmount, "RadicleToken::approve: amount exceeds 96 bits");
         }
 
-        allowances[msg.sender][spender] = amount;
+        allowances[owner][spender] = amount;
 
-        emit Approval(msg.sender, spender, amount);
-        return true;
+        emit Approval(owner, spender, amount);
     }
 
     /**
@@ -261,17 +275,39 @@ contract RadicleToken {
         bytes32 r,
         bytes32 s
     ) public {
-        bytes32 domainSeparator =
-            keccak256(
-                abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(NAME)), getChainId(), address(this))
-            );
         bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
         address signatory = ecrecover(digest, v, r, s);
         require(signatory != address(0), "RadicleToken::delegateBySig: invalid signature");
         require(nonce == nonces[signatory]++, "RadicleToken::delegateBySig: invalid nonce");
         require(block.timestamp <= expiry, "RadicleToken::delegateBySig: signature expired");
-        return _delegate(signatory, delegatee);
+        _delegate(signatory, delegatee);
+    }
+
+    /**
+     * @notice Approves spender to spend on behalf of owner.
+     * @param owner The signer of the permit
+     * @param spender The address to approve
+     * @param deadline The time at which the signature expires
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+        require(owner == ecrecover(digest, v, r, s), "RadicleToken::permit: invalid signature");
+        require(owner != address(0), "RadicleToken::permit: invalid signature");
+        require(block.timestamp <= deadline, "RadicleToken::permit: signature expired");
+        _approve(owner, spender, value);
     }
 
     /**

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -3,89 +3,190 @@
 pragma solidity ^0.7.5;
 
 import "@ensdomains/ens/contracts/ENS.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
+import "./Governance/RadicleToken.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
+// commitments are kept in a seperate contract to allow the state to be reused
+// between different versions of the registrar
+contract Commitments {
+    address public owner;
+    modifier auth { require(msg.sender == owner, "Commitments: unauthorized"); _; }
+    event SetOwner(address usr);
+
+    /// Mapping from the commitment to the block number in which the commitment was made
+    mapping(bytes32 => uint) public commited;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function setOwner(address usr) external auth {
+        owner = usr;
+        emit SetOwner(usr);
+    }
+
+    function commit(bytes32 commitment) external auth {
+        commited[commitment] = block.number;
+    }
+}
+
 contract Registrar {
+
+    // --- DATA ---
+
     /// The ENS registry.
     ENS public immutable ens;
 
-    /// The price oracle.
-    address public oracleAddress;
-
-    /// The Rad/Eth exchange.
-    address public exchangeAddress;
-
     /// The Radicle ERC20 token.
-    ERC20Burnable public immutable rad;
+    RadicleToken public immutable rad;
+
+    /// @notice EIP-712 name for this contract
+    string public constant NAME = "Registrar";
+
+    /// The commitment storage contract
+    Commitments public immutable commitments = new Commitments();
+
+    /// The namehash of the `eth` TLD in the ENS registry, eg. namehash("eth").
+    bytes32 public constant ethNode = keccak256(abi.encodePacked(bytes32(0), keccak256("eth")));
 
     /// The namehash of the node in the `eth` TLD, eg. namehash("radicle.eth").
-    bytes32 public immutable domain;
+    bytes32 public immutable radNode;
 
     /// The token ID for the node in the `eth` TLD, eg. sha256("radicle").
     uint256 public immutable tokenId;
 
-    /// Registration fee in *USD*.
-    uint256 public registrationFeeUsd = 10;
+    /// The minimum number of blocks that must have passed between a commitment and name registration
+    uint256 public minCommitmentAge;
 
     /// Registration fee in *Radicle* (uRads).
     uint256 public registrationFeeRad = 1e18;
 
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The EIP-712 typehash for the delegation struct used by the contract
+    bytes32 public constant COMMIT_TYPEHASH =
+        keccak256("Commit(bytes32 commitment,uint256 nonce,uint256 expiry,uint256 submissionFee)");
+
+    /// @notice A record of states for signing / validating signatures
+    mapping(address => uint256) public nonces;
+
+    // --- LOGS ---
+
+    /// @notice A name was registered.
+    event NameRegistered(string indexed name, bytes32 indexed label, address indexed owner);
+
+    /// @notice A commitment was made
+    event CommitmentMade(bytes32 commitment, uint blockNumber);
+
+    /// @notice The contract admin was changed
+    event AdminChanged(address newAdmin);
+
+    /// @notice The registration fee was changed
+    event RegistrationRadFeeChanged(uint amt);
+
+    /// @notice The ownership of the domain was changed
+    event DomainOwnershipChanged(address newOwner);
+
+    /// @notice The resolver changed
+    event ResolverChanged(address resolver);
+
+    /// @notice The ttl changed
+    event TTLChanged(uint64 amt);
+
+    /// @notice The minimum age for a commitment was changed
+    event MinCommitmentAgeChanged(uint256 amt);
+
+    // --- AUTH ---
+
     /// The contract admin who can set fees.
     address public admin;
 
-    /// @notice A name was registered.
-    event NameRegistered(bytes32 indexed label, address indexed owner);
-
     /// Protects admin-only functions.
     modifier adminOnly {
-        require(msg.sender == admin, "Only the admin can perform this action");
+        require(msg.sender == admin, "Registrar: only the admin can perform this action");
         _;
     }
 
+    // --- INIT ---
+
     constructor(
         ENS _ens,
-        bytes32 ethDomainNameHash,
-        uint256 ethDomainTokenId,
-        address _oracleAddress,
-        address _exchangeAddress,
-        ERC20Burnable _rad,
-        address adminAddress
+        RadicleToken _rad,
+        address _admin,
+        uint _minCommitmentAge,
+        bytes32 _radNode,
+        uint _tokenId
     ) {
         ens = _ens;
-        oracleAddress = _oracleAddress;
-        exchangeAddress = _exchangeAddress;
         rad = _rad;
-        domain = ethDomainNameHash;
-        tokenId = ethDomainTokenId;
-        admin = adminAddress;
+        admin = _admin;
+        minCommitmentAge = _minCommitmentAge;
+        radNode = _radNode;
+        tokenId = _tokenId;
     }
 
-    /// Register a subdomain using ether.
-    function registerEth(string memory, address) public payable {
-        revert("Registrar::registerEth: Registration using ETH is not yet available");
+    // --- USER FACING METHODS ---
+
+    /// Commit to a future name registration
+    function commit(bytes32 commitment) public {
+        _commit(msg.sender, commitment);
     }
 
-    /// Register a subdomain using radicle tokens.
-    function registerRad(string memory name, address owner) public {
-        uint256 fee = registrationFeeRad;
-
-        require(rad.balanceOf(msg.sender) >= fee, "Transaction includes registration fee");
-        require(valid(name), "Name must be valid");
-
-        _register(keccak256(bytes(name)), owner);
-
-        rad.burnFrom(msg.sender, fee);
+    /// Commit to a future name and submit permit in the same transaction
+    function commitWithPermit(bytes32 commitment, address owner, uint256 value,
+                              uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
+        rad.permit(owner, address(this), value, deadline, v, r, s);
+        _commit(msg.sender, commitment);
     }
 
-    function _register(bytes32 label, address owner) private {
-        bytes32 node = namehash(domain, label);
+    /// Commit to a future name with a 712-signed message
+    function commitBySig(bytes32 commitment, uint256 nonce, uint256 expiry, uint256 submissionFee, uint8 v, bytes32 r, bytes32 s) public {
+        bytes32 domainSeparator =
+            keccak256(
+                abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(NAME)), getChainId(), address(this))
+            );
+        bytes32 structHash = keccak256(abi.encode(COMMIT_TYPEHASH, commitment, nonce, expiry, submissionFee));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "Registrar::commitBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "Registrar::commitBySig: invalid nonce");
+        require(block.timestamp <= expiry, "Registrar::commitBySig: signature expired");
+        rad.transferFrom(signatory, msg.sender, submissionFee);
+        _commit(signatory, commitment);
+    }
 
-        require(!ens.recordExists(node), "Registrar::_register: name must be available");
+    /// Commit to a future name with a 712-signed message and submit permit in the same transaction
+    function commitBySigWithPermit(bytes32 commitment, uint256 nonce, uint256 expiry, uint256 submissionFee, uint8 v, bytes32 r, bytes32 s,
+                                   address owner, uint256 value, uint256 deadline, uint8 permit_v, bytes32 permit_r, bytes32 permit_s) public {
+        rad.permit(owner, address(this), value, deadline, permit_v, permit_r, permit_s);
+        commitBySig(commitment, nonce, expiry, submissionFee, v, r, s);
+    }
 
-        ens.setSubnodeOwner(domain, label, owner);
+    function _commit(address payer, bytes32 commitment) internal {
+        require(commitments.commited(commitment) == 0, "Registrar::commit: already commited");
 
-        emit NameRegistered(label, owner);
+        rad.burnFrom(payer, registrationFeeRad);
+        commitments.commit(commitment);
+
+        emit CommitmentMade(commitment, block.number);
+    }
+
+    /// Register a subdomain
+    function register(string calldata name, address owner, uint salt) external {
+        bytes32 label = keccak256(bytes(name));
+        bytes32 commitment = keccak256(abi.encodePacked(name, owner, salt));
+        uint256 commited = commitments.commited(commitment);
+
+        require(valid(name), "Registrar::register: invalid name");
+        require(available(name), "Registrar::register: name has already been registered");
+        require(commited != 0, "Registrar::register: must commit before registration");
+        require(commited + minCommitmentAge < block.number, "Registrar::register: commitment too new");
+
+        ens.setSubnodeRecord(radNode, label, owner, ens.resolver(radNode), ens.ttl(radNode));
+
+        emit NameRegistered(name, label, owner);
     }
 
     /// Check whether a name is valid.
@@ -97,9 +198,8 @@ contract Registrar {
     /// Check whether a name is available for registration.
     function available(string memory name) public view returns (bool) {
         bytes32 label = keccak256(bytes(name));
-        bytes32 node = namehash(domain, label);
-
-        return valid(name) && !ens.recordExists(node);
+        bytes32 node = namehash(radNode, label);
+        return ens.owner(node) == address(0);
     }
 
     /// Get the "namehash" of a label.
@@ -107,57 +207,55 @@ contract Registrar {
         return keccak256(abi.encodePacked(parent, label));
     }
 
-    /// Registration fee in ether.
-    function registrationFeeEth() public pure returns (uint256) {
-        revert("Registrar::registrationFeeEth: Registration using ETH is not yet available");
-    }
-
-    // ADMIN FUNCTIONS
-
-    /// Set the USD registration fee.
-    function setUsdRegistrationFee(uint256 fee) public adminOnly {
-        registrationFeeUsd = fee;
-    }
-
-    /// Set the radicle registration fee.
-    function setRadRegistrationFee(uint256 fee) public adminOnly {
-        registrationFeeRad = fee;
-    }
-
-    /// Set the price oracle.
-    function setPriceOracle(address _oracleAddress) public adminOnly {
-        require(
-            oracleAddress != address(0),
-            "Registrar::setPriceOracle: oracle address cannot be zero"
-        );
-        oracleAddress = _oracleAddress;
-    }
-
-    /// Set the exchange.
-    function setExchange(address _exchangeAddress) public adminOnly {
-        require(
-            exchangeAddress != address(0),
-            "Registrar::setExchange: exchange address cannot be zero"
-        );
-        exchangeAddress = _exchangeAddress;
-    }
+    // --- ADMIN METHODS ---
 
     /// Set the owner of the domain.
     function setDomainOwner(address newOwner) public adminOnly {
-        // The name hash of 'eth'
-        bytes32 ethNode = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
-        address ethRegistrarAddr = ens.owner(ethNode);
-        require(
-            ethRegistrarAddr != address(0),
-            "Registrar::setDomainOwner: no registrar found on ENS for the 'eth' domain"
-        );
-        ens.setRecord(domain, newOwner, newOwner, 0);
-        IERC721 ethRegistrar = IERC721(ethRegistrarAddr);
+        IERC721 ethRegistrar = IERC721(ens.owner(ethNode));
+
+        ens.setOwner(radNode, newOwner);
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
+        commitments.setOwner(newOwner);
+
+        emit DomainOwnershipChanged(newOwner);
+    }
+
+    /// Set a new resolver for radicle.eth.
+    function setDomainResolver(address resolver) public adminOnly {
+        ens.setResolver(radNode, resolver);
+        emit ResolverChanged(resolver);
+    }
+
+    /// Set a new ttl for radicle.eth
+    function setDomainTTL(uint64 ttl) public adminOnly {
+        ens.setTTL(radNode, ttl);
+        emit TTLChanged(ttl);
+    }
+
+    /// Set the minimum commitment age
+    function setMinCommitmentAge(uint256 amt) public adminOnly {
+        minCommitmentAge = amt;
+        emit MinCommitmentAgeChanged(amt);
+    }
+
+    /// Set a new registration fee
+    function setRadRegistrationFee(uint256 amt) public adminOnly {
+        registrationFeeRad = amt;
+        emit RegistrationRadFeeChanged(amt);
     }
 
     /// Set a new admin
-    function setAdmin(address _admin) public adminOnly {
-        admin = _admin;
+    function setAdmin(address newAdmin) public adminOnly {
+        admin = newAdmin;
+        emit AdminChanged(newAdmin);
+    }
+
+    function getChainId() internal pure returns (uint256) {
+        uint256 chainId;
+        // solhint-disable no-inline-assembly
+        assembly {
+            chainId := chainid()
+        }
+        return chainId;
     }
 }

--- a/contracts/deploy/phase0.sol
+++ b/contracts/deploy/phase0.sol
@@ -45,12 +45,11 @@ contract Phase0 {
         Registrar _registrar =
             new Registrar(
                 _ens,
+                _token,
+                address(_timelock),
+                10,
                 _namehash,
-                uint256(keccak256(bytes(_label))),
-                address(0), // oracle not used yet
-                address(0), // exchange not used yet
-                ERC20Burnable(address(_token)),
-                address(_timelock)
+                uint256(keccak256(bytes(_label)))
             );
 
         token = _token;

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -69,15 +69,15 @@ export async function deployAll(signer: Signer): Promise<DeployedContracts> {
   const gov = await deployGovernance(signer, timelock.address, rad.address, signerAddr);
   const exchange = await deployExchange(rad, signer);
   const label = "radicle";
+  const minCommitmentAge = 50;
   const ens = await deployTestEns(signer, label);
   const registrar = await deployRegistrar(
     signer,
-    await exchange.oracle(),
-    exchange.address,
-    rad.address,
     ens.address,
+    rad.address,
+    signerAddr,
     label,
-    signerAddr
+    minCommitmentAge
   );
   await transferEthDomain(ens, label, registrar.address);
   const ethPool = await deployEthPool(signer, 10);
@@ -118,22 +118,20 @@ export async function deployVestingToken(
 
 export async function deployRegistrar(
   signer: Signer,
-  oracle: string,
-  exchange: string,
-  token: string,
   ensAddr: string,
+  token: string,
+  admin: string,
   label: string,
-  admin: string
+  minCommitmentAge: BigNumberish
 ): Promise<Registrar> {
   return await deployOk(
     new Registrar__factory(signer).deploy(
       ensAddr,
-      utils.namehash(label + ".eth"),
-      labelHash(label),
-      oracle,
-      exchange,
       token,
-      admin
+      admin,
+      minCommitmentAge,
+      utils.namehash(label + ".eth"),
+      labelHash(label)
     )
   );
 }


### PR DESCRIPTION
Extracts the changes to RadicleToken and Registry from our fork at https://github.com/dapp-org/radicle-contracts, without including any of the testing infrastructure. Adapts the deployment contract and hardhat tests to the new Registry.
We have more tests at our fork, but they are left out of this PR as it would require more changes infrastructurally