### PR TITLE
Demote production dependencies to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "license": "GPL-3.0-only",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
-  "dependencies": {
-    "@ensdomains/ens": "^0.5.0",
-    "@uniswap/v2-periphery": "^1.1.0-beta.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@ensdomains/ens": "^0.5.0",
     "@ethersproject/abi": "^5.0.12",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@openzeppelin/contracts": "^3.4.1-solc-0.7",
@@ -18,6 +16,7 @@
     "@types/mocha": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "chai": "^4.3.3",
     "eslint": "^7.21.0",
     "ethers": "^5.0.31",


### PR DESCRIPTION
Both `@ensdomains/ens` and `@uniswap/v2-periphery` can by dev
dependencies. The packages are only used to build the project. The
build artifacts don’t contain references to the packages.