### PR TITLE
Clean up variable names around pool

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -631,12 +631,12 @@ abstract contract Pool {
         // The cycle delta is split proportionally based on how much this cycle is affected.
         // The next cycle has the rest of the delta applied, so the update is fully completed.
         uint64 thisCycle = timestamp / cycleSecs + 1;
-        uint64 nextCycleBlocks = timestamp % cycleSecs;
-        uint64 thisCycleBlocks = cycleSecs - nextCycleBlocks;
+        uint64 nextCycleSecs = timestamp % cycleSecs;
+        uint64 thisCycleSecs = cycleSecs - nextCycleSecs;
         proxyDeltas.addToDelta(
             thisCycle,
-            thisCycleBlocks * amtPerSecDelta,
-            nextCycleBlocks * amtPerSecDelta
+            thisCycleSecs * amtPerSecDelta,
+            nextCycleSecs * amtPerSecDelta
         );
     }
 
@@ -673,10 +673,10 @@ abstract contract Pool {
         // The cycle delta is split proportionally based on how much this cycle is affected.
         // The next cycle has the rest of the delta applied, so the update is fully completed.
         uint64 thisCycle = timestamp / cycleSecs + 1;
-        uint64 nextCycleBlocks = timestamp % cycleSecs;
-        uint64 thisCycleBlocks = cycleSecs - nextCycleBlocks;
-        amtDeltas[thisCycle].thisCycle += thisCycleBlocks * amtPerSecDelta;
-        amtDeltas[thisCycle].nextCycle += nextCycleBlocks * amtPerSecDelta;
+        uint64 nextCycleSecs = timestamp % cycleSecs;
+        uint64 thisCycleSecs = cycleSecs - nextCycleSecs;
+        amtDeltas[thisCycle].thisCycle += thisCycleSecs * amtPerSecDelta;
+        amtDeltas[thisCycle].nextCycle += nextCycleSecs * amtPerSecDelta;
     }
 
     /// @notice Stops proxy of `msg.sender` for the duration of the modified function.

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -240,16 +240,16 @@ export async function deployExchange(radToken: RadicleToken, signer: Signer): Pr
   return exchange;
 }
 
-export async function deployEthPool(signer: Signer, cycleBlocks: number): Promise<EthPool> {
-  return deployOk(new EthPool__factory(signer).deploy(cycleBlocks));
+export async function deployEthPool(signer: Signer, cycleSecs: number): Promise<EthPool> {
+  return deployOk(new EthPool__factory(signer).deploy(cycleSecs));
 }
 
 export async function deployErc20Pool(
   signer: Signer,
-  cycleBlocks: number,
+  cycleSecs: number,
   erc20TokenAddress: string
 ): Promise<Erc20Pool> {
-  return deployOk(new Erc20Pool__factory(signer).deploy(cycleBlocks, erc20TokenAddress));
+  return deployOk(new Erc20Pool__factory(signer).deploy(cycleSecs, erc20TokenAddress));
 }
 
 // The signer becomes an owner of the '', 'eth' and '<label>.eth' domains,


### PR DESCRIPTION
The switch of the pool contract from the block-based to the seconds-based time measurement hasn't been fully reflected in variable names. This PR fixes that.