### PR TITLE
Add dai pool

### DIFF
--- a/contracts/TestDai.sol
+++ b/contracts/TestDai.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.7.5;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract Dai is ERC20 {
+    bytes32 private immutable domainSeparator;
+    bytes32 private immutable typehash;
+    mapping(address => uint256) public nonces;
+
+    constructor() ERC20("DAI Stablecoin", "DAI") {
+        // TODO replace with `block.chainid` after upgrade to Solidity 0.8
+        uint256 chainId;
+        // solhint-disable no-inline-assembly
+        assembly {
+            chainId := chainid()
+        }
+        domainSeparator = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(name())),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+        typehash = keccak256(
+            "Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"
+        );
+        _mint(msg.sender, 10**9 * 10**18); // 1 billion DAI, 18 decimals
+    }
+
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        bytes32 message = keccak256(abi.encode(typehash, holder, spender, nonce, expiry, allowed));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, message));
+        address signer = ecrecover(digest, v, r, s);
+        require(holder == signer, "Invalid signature");
+        require(nonce == nonces[holder]++, "Invalid nonce");
+        require(expiry == 0 || expiry > block.timestamp, "Signature expired");
+        uint256 amount = allowed ? type(uint256).max : 0;
+        _approve(holder, spender, amount);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { deployAll, DeployedContracts } from "./deploy";
+export { daiPermitDigest } from "./utils";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,30 @@
+import { utils, BigNumberish } from "ethers";
+
+export function daiPermitDigest(
+  daiContract: string,
+  chainId: BigNumberish,
+  holder: string,
+  spender: string,
+  nonce: BigNumberish,
+  expiry: BigNumberish,
+  allowed: boolean
+): Uint8Array {
+  const domain = {
+    name: "DAI Stablecoin",
+    version: "1",
+    chainId,
+    verifyingContract: daiContract,
+  };
+  const types = {
+    Permit: [
+      { name: "holder", type: "address" },
+      { name: "spender", type: "address" },
+      { name: "nonce", type: "uint256" },
+      { name: "expiry", type: "uint256" },
+      { name: "allowed", type: "bool" },
+    ],
+  };
+  const value = { holder, spender, nonce, expiry, allowed };
+  const hash = utils._TypedDataEncoder.hash(domain, types, value);
+  return utils.arrayify(hash);
+}


### PR DESCRIPTION
This is a part of https://github.com/radicle-dev/radicle-contracts/issues/128 for the special case of Dai. This token isn't fully EIP-2612 compatible, but it's used in upstream.

This PR adds a basic implementation of Dai, which is just an ERC-20 with `permit`. The real Dai contract doesn't compile with modern versions of Solidity and there are no yarn packages with it already precompiled. We also need its API, which is available as a package, but it too needs old Solidity to work. An alternative would be to pull the Dai source code, compile it to a JSON and keep a copy of it in our repo. I think that with such simple contract it's clearer to maintain these few lines of code instead of a binary blob.