### PR TITLE
Move contract declaration files into build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,4 +17,13 @@ module.exports = {
   rules: {
     "@typescript-eslint/explicit-function-return-type": "error",
   },
+  overrides: [
+    {
+      files: "*.js",
+      rules: {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-var-requires": "off",
+      },
+    },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "chai": "^4.3.3",
     "eslint": "^7.21.0",
+    "fast-glob": "^3.2.7",
     "hardhat": "^2.1.1",
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.5",
@@ -36,7 +37,7 @@
     "web3": "^1.3.5"
   },
   "scripts": {
-    "build": "hardhat compile && tsc",
+    "build": "hardhat compile && tsc && node scripts/copy-contract-declaration-files.js",
     "deploy:claims": "ts-node -e 'require(\"./src/deploy-to-network.ts\").claims();'",
     "deploy:ethFundingPool": "ts-node -e 'require(\"./src/deploy-to-network.ts\").ethFundingPool();'",
     "deploy:erc20FundingPool": "ts-node -e 'require(\"./src/deploy-to-network.ts\").erc20FundingPool();'",

--- a/scripts/copy-contract-declaration-files.js
+++ b/scripts/copy-contract-declaration-files.js
@@ -1,0 +1,23 @@
+const path = require("path");
+const fs = require("fs").promises;
+const fastGlob = require("fast-glob");
+
+// Copies all `.d.ts` files from `contract-bindings` to the build
+// directory so that dependents pick them up properly.
+//
+// See https://github.com/ethereum-ts/TypeChain/issues/430
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async function main() {
+  const projectRoot = path.resolve(__dirname, "..");
+  const declarationFiles = await fastGlob(
+    ["contract-bindings/ethers/**/*.d.ts"],
+    { cwd: projectRoot }
+  );
+  for (const file of declarationFiles) {
+    await fs.copyFile(
+      path.resolve(projectRoot, file),
+      path.resolve(projectRoot, "build", file)
+    );
+  }
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
+    "scripts/**/*.js",
     "contract-bindings/**/*.ts"
   ],
   "exclude": ["node_modules"],
@@ -21,6 +22,8 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
+    "allowJs": true,
+    "checkJs": true,
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,6 +2670,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2951,6 +2962,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -3986,6 +4004,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -4579,6 +4605,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
We move the contract declaration files into the build directory so that they can be properly resolved when we require factory modules like `import "radicle-contracts/build/contract-bindings/ethers"`.

This is a workaround for https://github.com/ethereum-ts/TypeChain/issues/430.